### PR TITLE
Ar Update yaml loader

### DIFF
--- a/safe_control_gym/utils/registration.py
+++ b/safe_control_gym/utils/registration.py
@@ -55,7 +55,7 @@ class Spec():
                 # Specified as file path.
                 mod_name, config_name = self.config_entry_point.split(":")
                 with pkg_resources.open_text(mod_name, config_name) as f:
-                    config = yaml.safe_load(f)
+                    config = yaml.load(f, Loader=yaml.FullLoader)
             else:
                 # Specified as "module_path:config_dict_name".
                 config = load(self.config_entry_point)

--- a/safe_control_gym/utils/registration.py
+++ b/safe_control_gym/utils/registration.py
@@ -55,7 +55,7 @@ class Spec():
                 # Specified as file path.
                 mod_name, config_name = self.config_entry_point.split(":")
                 with pkg_resources.open_text(mod_name, config_name) as f:
-                    config = yaml.load(f)
+                    config = yaml.safe_load(f)
             else:
                 # Specified as "module_path:config_dict_name".
                 config = load(self.config_entry_point)

--- a/safe_control_gym/utils/utils.py
+++ b/safe_control_gym/utils/utils.py
@@ -51,7 +51,7 @@ def read_file(file_path, sep=","):
     if "json" in file_path:
         data = json.load(f)
     elif "yaml" in file_path:
-        data = yaml.safe_load(f)
+        data = yaml.load(f, Loader=yaml.FullLoader)
     else:
         sep = sep if "csv" in file_path else " "
         data = []

--- a/safe_control_gym/utils/utils.py
+++ b/safe_control_gym/utils/utils.py
@@ -51,7 +51,7 @@ def read_file(file_path, sep=","):
     if "json" in file_path:
         data = json.load(f)
     elif "yaml" in file_path:
-        data = yaml.load(f)
+        data = yaml.safe_load(f)
     else:
         sep = sep if "csv" in file_path else " "
         data = []


### PR DESCRIPTION
In pyyaml 6.0, yaml.load() function gives the following error:

> TypeError: load() missing 1 required positional argument: 'Loader'

Either reverting back to pyyaml==5.4.1 or using yaml.safe_load() <[ref](https://stackoverflow.com/questions/1773805/how-can-i-parse-a-yaml-file-in-python/1774043#1774043)> solve the problem. 