### PR TITLE
Make slack parameter into list if initialized as int/float 

### DIFF
--- a/safe_control_gym/controllers/safe_explorer/safe_explorer_utils.py
+++ b/safe_control_gym/controllers/safe_explorer/safe_explorer_utils.py
@@ -52,7 +52,7 @@ class SafetyLayer:
         # Constraint slack variables/values.
         assert slack is not None and isinstance(slack, (int, float, list))
         if isinstance(slack, (int, float)):
-            slack = [slack]
+            slack = [slack]*obs_space.shape[0]
         self.slack = np.array(slack)
         # Optimizers.
         self.optimizers = [


### PR DESCRIPTION
Change:
Making slack into list of length obs dim when not already a list to ensure no failure at line 168 where slack is indexed. 

Additional Comments: 
Might be good to have a length check on if it is a list as well