### PR TITLE
bug fix for explicit dynamics of 2d quadrotor

### DIFF
--- a/safe_control_gym/envs/gym_pybullet_drones/base_aviary.py
+++ b/safe_control_gym/envs/gym_pybullet_drones/base_aviary.py
@@ -549,10 +549,10 @@ class BaseAviary(BenchmarkEnv):
         rpy_rates_deriv = np.dot(self.J_INV, torques)
         no_pybullet_dyn_accs = force_world_frame / self.MASS
         # Update state.
-        vel = vel + self.TIMESTEP * no_pybullet_dyn_accs
-        rpy_rates = rpy_rates + self.TIMESTEP * rpy_rates_deriv
-        pos = pos + self.TIMESTEP * vel
-        rpy = rpy + self.TIMESTEP * rpy_rates
+        vel = vel + self.PYB_TIMESTEP * no_pybullet_dyn_accs
+        rpy_rates = rpy_rates + self.PYB_TIMESTEP * rpy_rates_deriv
+        pos = pos + self.PYB_TIMESTEP * vel
+        rpy = rpy + self.PYB_TIMESTEP * rpy_rates
         # Set PyBullet's state.
         p.resetBasePositionAndOrientation(self.DRONE_IDS[nth_drone],
                                           pos,


### PR DESCRIPTION
If the dynamics are changed to the explicit dynamics for the tracking example (tracking.yaml, line 7 -> physics: dyn) and tracking.py is run, the following error occurs:

**Commands**
```
cd examples
python3 tracking.py --overrides ./tracking.yaml
```

**Error stack**
```
Traceback (most recent call last):
  File "tracking.py", line 77, in <module>
    main()
  File "tracking.py", line 58, in main
    results = ctrl.run(iterations=ITERATIONS)
  File "/home/hanna/Data/Research/SafeRL/safe-control-gym/safe_control_gym/controllers/pid/pid.py", line 97, in run
    obs, reward, done, info = self.env.step(action)
  File "/home/hanna/Data/Research/SafeRL/safe-control-gym/safe_control_gym/envs/gym_pybullet_drones/quadrotor.py", line 367, in step
    super()._advance_simulation(rpm, disturb_force)
  File "/home/hanna/Data/Research/SafeRL/safe-control-gym/safe_control_gym/envs/gym_pybullet_drones/base_aviary.py", line 285, in _advance_simulation
    self._dynamics(clipped_action[i, :], i)
  File "/home/hanna/Data/Research/SafeRL/safe-control-gym/safe_control_gym/envs/gym_pybullet_drones/base_aviary.py", line 552, in _dynamics
    vel = vel + self.TIMESTEP * no_pybullet_dyn_accs
AttributeError: 'Quadrotor' object has no attribute 'TIMESTEP'
```

This is because the attribute self.TIMESTEP is not defined. Minor changes in the _dynamics function solve this issue. A proposal how to fix this is created as pull request.