### PR TITLE
Adding basic testing

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,35 @@
+# This workflow will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Test package quality
+
+on: push
+
+permissions:
+  contents: read
+
+jobs:
+  run_tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.8'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pytest
+    - name: Install package
+      run: |
+        pip install -e .
+    - name: Unit tests
+      run: |
+        python -m pytest tests/
+        rm -rf tmp/

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,6 +1,3 @@
-# This workflow will upload a Python Package using Twine when a release is created
-# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
-
 # This workflow uses actions that are not certified by GitHub.
 # They are provided by a third-party and are governed by
 # separate terms of service, privacy policy, and support

--- a/examples/tracking.py
+++ b/examples/tracking.py
@@ -15,7 +15,7 @@ from functools import partial
 from safe_control_gym.utils.configuration import ConfigFactory
 from safe_control_gym.utils.registration import make
 
-def main():
+def run(gui=True, max_steps=10000):
     """The main function creating, running, and closing an environment.
 
     """
@@ -26,7 +26,10 @@ def main():
     
     # Set iterations and episode counter.
     ITERATIONS = int(config.quadrotor_config['episode_len_sec']*config.quadrotor_config['ctrl_freq'])
-    
+    ITERATIONS = min(ITERATIONS, max_steps)
+
+    config.quadrotor_config['gui'] = gui
+
     for i in range(3):
         # Start a timer.
         START = time.time()
@@ -48,11 +51,12 @@ def main():
         reference_traj = ctrl.reference
 
         # Plot trajectory.
-        for i in range(0, reference_traj.shape[0], 10):
-            p.addUserDebugLine(lineFromXYZ=[reference_traj[i-10,0], 0, reference_traj[i-10,2]],
-                               lineToXYZ=[reference_traj[i,0], 0, reference_traj[i,2]],
-                               lineColorRGB=[1, 0, 0],
-                               physicsClientId=ctrl.env.PYB_CLIENT)
+        if gui:
+            for i in range(0, reference_traj.shape[0], 10):
+                p.addUserDebugLine(lineFromXYZ=[reference_traj[i-10,0], 0, reference_traj[i-10,2]],
+                                lineToXYZ=[reference_traj[i,0], 0, reference_traj[i,2]],
+                                lineColorRGB=[1, 0, 0],
+                                physicsClientId=ctrl.env.PYB_CLIENT)
 
         # Run the experiment.
         results = ctrl.run(iterations=ITERATIONS)
@@ -74,4 +78,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    run()

--- a/examples/verbose_api.py
+++ b/examples/verbose_api.py
@@ -2,22 +2,18 @@
 
 Example:
 
-    $ python3 verbose_api.py --overrides ./verbose_api.yaml --system quadrotor
+    $ python3 verbose_api.py --overrides ./verbose_api.yaml
 
 """
 import time
-import yaml
 import inspect
-import numpy as np
 import pybullet as p
-import casadi as cs
 
-from safe_control_gym.utils.utils import str2bool
 from safe_control_gym.utils.configuration import ConfigFactory
 from safe_control_gym.utils.registration import make
 
 
-def main():
+def run():
     """The main function creating, running, and closing an environment.
 
     """
@@ -158,4 +154,4 @@ def print_str_with_style(string: str='', style: int=0):
 
 
 if __name__ == "__main__":
-    main()
+    run()

--- a/experiments/pid/pid_experiment.py
+++ b/experiments/pid/pid_experiment.py
@@ -14,8 +14,10 @@ from functools import partial
 
 from safe_control_gym.utils.configuration import ConfigFactory
 from safe_control_gym.utils.registration import make
+from safe_control_gym.envs.benchmark_env import Task
 
-def main():
+
+def run(gui=True, max_steps=10000):
     """The main function creating, running, and closing an environment.
 
     """
@@ -26,9 +28,12 @@ def main():
     
     # Set iterations and episode counter.
     ITERATIONS = int(config.quadrotor_config['episode_len_sec']*config.quadrotor_config['ctrl_freq'])
+    ITERATIONS = min(ITERATIONS, max_steps)
     
     # Start a timer.
     START = time.time()
+
+    config.quadrotor_config['gui'] = gui
     
     # Create controller.
     env_func = partial(make,
@@ -39,7 +44,7 @@ def main():
                 env_func,
                 )
                 
-    if config.quadrotor_config.task == 'traj_tracking':
+    if config.quadrotor_config.task == Task.TRAJ_TRACKING and gui:
         reference_traj = ctrl.reference
 
         # Plot trajectory.
@@ -50,7 +55,7 @@ def main():
                                 physicsClientId=ctrl.env.PYB_CLIENT)
 
     # Run the experiment.
-    results = ctrl.run( iterations=ITERATIONS)
+    results = ctrl.run(iterations=ITERATIONS)
     ctrl.close()
             
     # Plot the experiment.
@@ -68,4 +73,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    run()

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1,0 +1,6 @@
+def test_imports():
+    import safe_control_gym
+    import safe_control_gym.controllers
+    import safe_control_gym.envs
+    import safe_control_gym.envs.env_wrappers
+    import safe_control_gym.utils

--- a/tests/test_examples/test_examples.py
+++ b/tests/test_examples/test_examples.py
@@ -1,0 +1,12 @@
+import sys
+
+from examples.tracking import run as tracking_run
+from examples.verbose_api import run as verbose_run
+
+def test_tracking():
+    sys.argv[1:] = ['--overrides', './examples/tracking.yaml'] 
+    tracking_run(gui=False, max_steps=10)
+
+def test_verbose_api():
+    sys.argv[1:] = ['--overrides', './examples/verbose_api.yaml']
+    verbose_run()

--- a/tests/test_experiments/test_pid/test_pid.py
+++ b/tests/test_experiments/test_pid/test_pid.py
@@ -1,0 +1,11 @@
+import sys
+
+from experiments.pid.pid_experiment import run
+
+def test_pid_trajectory_tracking():
+    sys.argv[1:] = ['--task', 'quadrotor', '--algo', 'pid', '--overrides', './experiments/pid/config_pid_quadrotor.yaml'] 
+    run(gui=False, max_steps=10)
+
+def test_pid_stabilization():
+    sys.argv[1:] = ['--task', 'quadrotor', '--algo', 'pid', '--overrides', './experiments/pid/config_pid_quadrotor_stabilization.yaml'] 
+    run(gui=False, max_steps=10)


### PR DESCRIPTION
Added test files that run the example experiments and the PID experiments for 10 iterations. If the tests do not throw an error, they are considered to have passed. This test structure can be extended to run all the experiments in the `experiments` folder for a short horizon to determine failure. More extensive tests (confirming valid results) can also be done using this framework. 

The tests can be manually run from the project root using `python -m pytest tests/`

The GitHub flow runs the tests on every push. The results can be seen in the actions tab, seen in my repo here: https://github.com/Federico-PizarroBejarano/safe-control-gym/actions. The GitHub repo can be configured to prevent merging into `main` until the tests pass, although this needs to be done after this PR is merged I believe. 