### PR TITLE
Fixed gpmpc experiments to account for PR #35

### DIFF
--- a/experiments/annual_reviews/figure6/config_overrides/gp_mpc_quad.yaml
+++ b/experiments/annual_reviews/figure6/config_overrides/gp_mpc_quad.yaml
@@ -81,6 +81,9 @@ task_config:
       upper_bounds:
         - 0.2
         - 0.2
+      lower_bounds:
+        - 0.0
+        - 0.0
   done_on_violation: True
   disturbances: null
   init_state_randomization_info:

--- a/experiments/annual_reviews/figure6/config_overrides/gp_mpc_quad_training.yaml
+++ b/experiments/annual_reviews/figure6/config_overrides/gp_mpc_quad_training.yaml
@@ -79,6 +79,9 @@ task_config:
       upper_bounds:
         - 0.2
         - 0.2
+      lower_bounds:
+        - 0.0
+        - 0.0
   done_on_violation: True
   disturbances: null
   init_state_randomization_info:

--- a/experiments/arxiv/quadrotor_performance/config_overrides/gpmpc_quadrotor_data_eff.yaml
+++ b/experiments/arxiv/quadrotor_performance/config_overrides/gpmpc_quadrotor_data_eff.yaml
@@ -80,7 +80,7 @@ terminate_test_on_done: False
 output_dir: temp-data
 rand_kernel_selection: false
 restore: null
-seed: 5123 #0
+seed: 0
 tag: quad_data_eff
 task_config:
   constraints:


### PR DESCRIPTION
PR #35 changes the default action_space of the environment. The action_space is used to create the default MPC input constraints. These are small fixes to the YAMLS to make sure the experiment results are reasonably similar.