### PR TITLE
Allow varying env model priors for PID, LQR, and MPC 

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,3 +279,5 @@ $ ./create_unsafe_ppo_model.sh                                     # Run the scr
 
 -----
 > University of Toronto's [Dynamic Systems Lab](https://github.com/utiasDSL) / [Vector Institute for Artificial Intelligence](https://github.com/VectorInstitute)
+
+

--- a/experiments/pid/config_overrides/pid.yaml
+++ b/experiments/pid/config_overrides/pid.yaml
@@ -1,0 +1,7 @@
+algo_config:
+  # this is the default params in cartpole so don't need to specify again here
+  # but it serves as a example/template if any change to the prior is needed
+  prior_info:
+    prior_prop:
+      M: 0.027
+      Iyy: 0.000014

--- a/experiments/pid/config_overrides/quadrotor_stabilization.yaml
+++ b/experiments/pid/config_overrides/quadrotor_stabilization.yaml
@@ -43,3 +43,9 @@ task_config:
   episode_len_sec: 6
   cost: quadratic
   done_on_out_of_bound: False
+
+algo_config:
+  prior_info:
+    prior_prop:
+      M: 0.027
+      Iyy: 0.000014

--- a/experiments/pid/config_overrides/quadrotor_stabilization.yaml
+++ b/experiments/pid/config_overrides/quadrotor_stabilization.yaml
@@ -43,9 +43,3 @@ task_config:
   episode_len_sec: 6
   cost: quadratic
   done_on_out_of_bound: False
-
-algo_config:
-  prior_info:
-    prior_prop:
-      M: 0.027
-      Iyy: 0.000014

--- a/experiments/pid/config_overrides/quadrotor_tracking.yaml
+++ b/experiments/pid/config_overrides/quadrotor_tracking.yaml
@@ -48,3 +48,9 @@ task_config:
   episode_len_sec: 6
   cost: quadratic
   done_on_out_of_bound: False
+
+algo_config:
+  prior_info:
+    prior_prop:
+      M: 0.027
+      Iyy: 0.000014

--- a/experiments/pid/config_overrides/quadrotor_tracking.yaml
+++ b/experiments/pid/config_overrides/quadrotor_tracking.yaml
@@ -48,9 +48,3 @@ task_config:
   episode_len_sec: 6
   cost: quadratic
   done_on_out_of_bound: False
-
-algo_config:
-  prior_info:
-    prior_prop:
-      M: 0.027
-      Iyy: 0.000014

--- a/experiments/pid/pid_experiment.sh
+++ b/experiments/pid/pid_experiment.sh
@@ -3,7 +3,7 @@
 # PID Experiment.
 
 ## Stabilization
-python3 ./pid_experiment.py --task quadrotor --algo pid --overrides ./config_overrides/quadrotor_stabilization.yaml
+python3 ./pid_experiment.py --task quadrotor --algo pid --overrides ./config_overrides/quadrotor_stabilization.yaml ./config_overrides/pid.yaml
 
 ## Tracking
-python3 ./pid_experiment.py --task quadrotor --algo pid --overrides ./config_overrides/quadrotor_tracking.yaml
+python3 ./pid_experiment.py --task quadrotor --algo pid --overrides ./config_overrides/quadrotor_tracking.yaml ./config_overrides/pid.yaml

--- a/safe_control_gym/controllers/base_controller.py
+++ b/safe_control_gym/controllers/base_controller.py
@@ -127,3 +127,11 @@ class BaseController(ABC):
     def setup_results_dict(self):
         '''Setup the results dictionary to store run information. '''
         self.results_dict = {}
+        
+    def setup_prior(self):
+        '''Changes the prior model fetched from `self.env` for the controller.
+        '''
+        prior_info = getattr(self, "prior_info", None)
+        if prior_info is not None:
+            # TODO: it does not work currently, since `_setup_symbolic()` doesn't take any args
+            self.env._setup_symbolic(prior_info)

--- a/safe_control_gym/controllers/base_controller.py
+++ b/safe_control_gym/controllers/base_controller.py
@@ -185,7 +185,7 @@ class BaseController(ABC):
 
         # Note we only reset the symbolic model when prior_prop is nonempty
         if prior_prop:
-            prior_model = env._setup_symbolic(prior_prop=prior_prop)
+            env._setup_symbolic(prior_prop=prior_prop)
 
         # Note this ensures the env can still access the prior model, 
         # which is used to get quadratic costs in env.step()

--- a/safe_control_gym/controllers/pid/pid.py
+++ b/safe_control_gym/controllers/pid/pid.py
@@ -54,14 +54,12 @@ class PID(BaseController):
         super().__init__(env_func, **kwargs)
 
         self.env = env_func()
-        self.model = self.get_prior(self.env)
-
+        
         if self.env.NAME != Environment.QUADROTOR:
             raise NotImplementedError('[ERROR] PID not implemented for any system other than Quadrotor (2D and 3D).')
 
         self.env.reset()
         self.g = g
-        self.GRAVITY = g * self.model.quad_mass # The gravitational force (g*M) acting on each drone.
         self.KF = kf
         self.KM = km
         self.P_COEFF_FOR = np.array(p_coeff_for)
@@ -250,6 +248,8 @@ class PID(BaseController):
         '''Resets the control classes. The previous step's and integral
            errors for both position and attitude are set to zero.
         '''
+        self.model = self.get_prior(self.env)
+        self.GRAVITY = self.g * self.model.quad_mass # The gravitational force (g*M) acting on each drone.
         self.env.reset()
         self.reset_before_run()
 

--- a/safe_control_gym/controllers/pid/pid.py
+++ b/safe_control_gym/controllers/pid/pid.py
@@ -54,6 +54,7 @@ class PID(BaseController):
         super().__init__(env_func, **kwargs)
 
         self.env = env_func()
+        self.model = self.get_prior(self.env)
 
         if self.env.NAME != Environment.QUADROTOR:
             raise NotImplementedError('[ERROR] PID not implemented for any system other than Quadrotor (2D and 3D).')
@@ -61,7 +62,7 @@ class PID(BaseController):
         self.env.reset()
         self.g = g
         # self.GRAVITY = g * self.env.OVERRIDDEN_QUAD_MASS # The gravitational force (g*M) acting on each drone.
-        self.GRAVITY = g * self.env.PRIOR_MASS
+        self.GRAVITY = g * self.model.quad_mass
         self.KF = kf
         self.KM = km
         self.P_COEFF_FOR = np.array(p_coeff_for)
@@ -260,12 +261,10 @@ class PID(BaseController):
         self.last_rpy = np.zeros(3)
         self.integral_rpy_e = np.zeros(3)
 
-        if env is None:
-            # self.GRAVITY = self.g * self.env.OVERRIDDEN_QUAD_MASS
-            self.GRAVITY = self.g * self.env.PRIOR_MASS
-        else:
-            # self.GRAVITY = self.g * env.OVERRIDDEN_QUAD_MASS
-            self.GRAVITY = self.g * env.PRIOR_MASS
+        # if env is None:
+        #     self.GRAVITY = self.g * self.env.OVERRIDDEN_QUAD_MASS
+        # else:
+        #     self.GRAVITY = self.g * env.OVERRIDDEN_QUAD_MASS
 
         self.setup_results_dict()
 

--- a/safe_control_gym/controllers/pid/pid.py
+++ b/safe_control_gym/controllers/pid/pid.py
@@ -60,7 +60,8 @@ class PID(BaseController):
 
         self.env.reset()
         self.g = g
-        self.GRAVITY = g * self.env.OVERRIDDEN_QUAD_MASS # The gravitational force (g*M) acting on each drone.
+        # self.GRAVITY = g * self.env.OVERRIDDEN_QUAD_MASS # The gravitational force (g*M) acting on each drone.
+        self.GRAVITY = g * self.env.PRIOR_MASS
         self.KF = kf
         self.KM = km
         self.P_COEFF_FOR = np.array(p_coeff_for)
@@ -260,9 +261,11 @@ class PID(BaseController):
         self.integral_rpy_e = np.zeros(3)
 
         if env is None:
-            self.GRAVITY = self.g * self.env.OVERRIDDEN_QUAD_MASS
+            # self.GRAVITY = self.g * self.env.OVERRIDDEN_QUAD_MASS
+            self.GRAVITY = self.g * self.env.PRIOR_MASS
         else:
-            self.GRAVITY = self.g * env.OVERRIDDEN_QUAD_MASS
+            # self.GRAVITY = self.g * env.OVERRIDDEN_QUAD_MASS
+            self.GRAVITY = self.g * env.PRIOR_MASS
 
         self.setup_results_dict()
 

--- a/safe_control_gym/controllers/pid/pid.py
+++ b/safe_control_gym/controllers/pid/pid.py
@@ -61,8 +61,7 @@ class PID(BaseController):
 
         self.env.reset()
         self.g = g
-        # self.GRAVITY = g * self.env.OVERRIDDEN_QUAD_MASS # The gravitational force (g*M) acting on each drone.
-        self.GRAVITY = g * self.model.quad_mass
+        self.GRAVITY = g * self.model.quad_mass # The gravitational force (g*M) acting on each drone.
         self.KF = kf
         self.KM = km
         self.P_COEFF_FOR = np.array(p_coeff_for)
@@ -260,12 +259,6 @@ class PID(BaseController):
         self.integral_pos_e = np.zeros(3)
         self.last_rpy = np.zeros(3)
         self.integral_rpy_e = np.zeros(3)
-
-        # if env is None:
-        #     self.GRAVITY = self.g * self.env.OVERRIDDEN_QUAD_MASS
-        # else:
-        #     self.GRAVITY = self.g * env.OVERRIDDEN_QUAD_MASS
-
         self.setup_results_dict()
 
     def close(self):

--- a/safe_control_gym/envs/benchmark_env.py
+++ b/safe_control_gym/envs/benchmark_env.py
@@ -298,7 +298,7 @@ class BenchmarkEnv(gym.Env, ABC):
         return randomized_values
 
     @abstractmethod
-    def _setup_symbolic(self):
+    def _setup_symbolic(self, prior_prop={}, **kwargs):
         '''Creates a symbolic (CasADi) model for dynamics and cost. '''
         raise NotImplementedError
 

--- a/safe_control_gym/envs/benchmark_env.py
+++ b/safe_control_gym/envs/benchmark_env.py
@@ -299,7 +299,11 @@ class BenchmarkEnv(gym.Env, ABC):
 
     @abstractmethod
     def _setup_symbolic(self, prior_prop={}, **kwargs):
-        '''Creates a symbolic (CasADi) model for dynamics and cost. '''
+        '''Creates a symbolic (CasADi) model for dynamics and cost. 
+        
+        Args:
+            prior_prop (dict): specify the prior inertial prop to use in the symbolic model.
+        '''
         raise NotImplementedError
 
     def _setup_disturbances(self):

--- a/safe_control_gym/envs/gym_control/cartpole.py
+++ b/safe_control_gym/envs/gym_control/cartpole.py
@@ -124,7 +124,6 @@ class CartPole(BenchmarkEnv):
 
     def __init__(self,
                  init_state=None,
-                 prior_prop=None,
                  inertial_prop=None,
                  # custom args
                  obs_goal_horizon=0,
@@ -140,7 +139,6 @@ class CartPole(BenchmarkEnv):
         Args:
             init_state  (ndarray/dict, optional): The initial state of the environment.
                 (x, x_dot, theta, theta_dot).
-            prior_prop (dict, optional): The prior inertial properties of the environment.
             inertial_prop (dict, optional): The ground truth inertial properties of the environment.
             obs_goal_horizon (int): How many future goal states to append to obervation.
             obs_wrap_angle (bool): If to wrap angle to [-pi, pi] when used in observation.
@@ -157,7 +155,7 @@ class CartPole(BenchmarkEnv):
         self.done_on_out_of_bound = done_on_out_of_bound
         # BenchmarkEnv constructor, called after defining the custom args,
         # since some BenchmarkEnv init setup can be task(custom args)-dependent.
-        super().__init__(init_state=init_state, prior_prop=prior_prop, inertial_prop=inertial_prop, **kwargs)
+        super().__init__(init_state=init_state, inertial_prop=inertial_prop, **kwargs)
 
         # Create PyBullet client connection.
         self.PYB_CLIENT = -1
@@ -201,19 +199,6 @@ class CartPole(BenchmarkEnv):
         else:
             raise ValueError('[ERROR] in CartPole.__init__(), inertial_prop incorrect format.')
 
-        # Store prior parameters.
-        if prior_prop is None:
-            self.PRIOR_EFFECTIVE_POLE_LENGTH = EFFECTIVE_POLE_LENGTH
-            self.PRIOR_POLE_MASS = POLE_MASS
-            self.PRIOR_CART_MASS = CART_MASS
-        elif isinstance(prior_prop, dict):
-            self.PRIOR_EFFECTIVE_POLE_LENGTH = prior_prop.get('pole_length', EFFECTIVE_POLE_LENGTH)
-            self.PRIOR_POLE_MASS = prior_prop.get('pole_mass', POLE_MASS)
-            self.PRIOR_CART_MASS = prior_prop.get('cart_mass', CART_MASS)
-        else:
-            raise ValueError('[ERROR] in CartPole.__init__(), prior_prop incorrect format.')
-        # Set prior/symbolic info.
-        self._setup_symbolic()
         # Create X_GOAL and U_GOAL references for the assigned task.
         self.U_GOAL = np.zeros(1)
         if self.TASK == Task.STABILIZATION:
@@ -233,9 +218,9 @@ class CartPole(BenchmarkEnv):
                 np.zeros(POS_REF.shape[0]),
                 np.zeros(VEL_REF.shape[0])
             ]).transpose()
-        # Define equilibrium point about the upright equilibrium for stabilization or first point in trajectory.
-        self.X_EQ = np.atleast_2d(self.X_GOAL)[0,:].T
-        self.U_EQ = np.atleast_2d(self.U_GOAL)[0,:]
+            
+        # Set prior/symbolic info.
+        self._setup_symbolic()
 
     def step(self, action):
         '''Advances the environment by one control step.
@@ -392,9 +377,11 @@ class CartPole(BenchmarkEnv):
             p.disconnect(physicsClientId=self.PYB_CLIENT)
         self.PYB_CLIENT = -1
 
-    def _setup_symbolic(self):
+    def _setup_symbolic(self, prior_prop={}, **kwargs):
         '''Creates symbolic (CasADi) models for dynamics, observation, and cost. '''
-        l, m, M = self.PRIOR_EFFECTIVE_POLE_LENGTH, self.PRIOR_POLE_MASS, self.PRIOR_CART_MASS
+        l = prior_prop.get("pole_length", self.EFFECTIVE_POLE_LENGTH)
+        m = prior_prop.get("pole_mass", self.POLE_MASS)
+        M = prior_prop.get("cart_mass", self.CART_MASS)
         Mm, ml = m + M, m * l
         g = self.GRAVITY_ACC
         dt = self.CTRL_TIMESTEP
@@ -422,8 +409,13 @@ class CartPole(BenchmarkEnv):
         # Define dynamics and cost dictionaries.
         dynamics = {'dyn_eqn': X_dot, 'obs_eqn': Y, 'vars': {'X': X, 'U': U}}
         cost = {'cost_func': cost_func, 'vars': {'X': X, 'U': U, 'Xr': Xr, 'Ur': Ur, 'Q': Q, 'R': R}}
+        # Additional params to cache
+        params = {
+            "X_EQ": np.atleast_2d(self.X_GOAL)[0,:].T,
+            "U_EQ": np.atleast_2d(self.U_GOAL)[0,:],
+        }
         # Setup symbolic model.
-        self.symbolic = SymbolicModel(dynamics=dynamics, cost=cost, dt=dt)
+        self.symbolic = SymbolicModel(dynamics=dynamics, cost=cost, dt=dt, params=params)
 
     def _set_action_space(self):
         '''Sets the action space of the environment. '''

--- a/safe_control_gym/envs/gym_control/cartpole.py
+++ b/safe_control_gym/envs/gym_control/cartpole.py
@@ -663,9 +663,9 @@ class CartPole(BenchmarkEnv):
         info = {}
         info['symbolic_model'] = self.symbolic
         info['physical_parameters'] = {
-            'pole_effective_length': self.PRIOR_EFFECTIVE_POLE_LENGTH,
-            'pole_mass': self.PRIOR_POLE_MASS,
-            'cart_mass': self.PRIOR_CART_MASS
+            'pole_effective_length': self.EFFECTIVE_POLE_LENGTH,
+            'pole_mass': self.POLE_MASS,
+            'cart_mass': self.CART_MASS
         }
         info['x_reference'] = self.X_GOAL
         info['u_reference'] = self.U_GOAL

--- a/safe_control_gym/envs/gym_control/cartpole.py
+++ b/safe_control_gym/envs/gym_control/cartpole.py
@@ -672,9 +672,9 @@ class CartPole(BenchmarkEnv):
         info = {}
         info['symbolic_model'] = self.symbolic
         info['physical_parameters'] = {
-            'pole_effective_length': self.EFFECTIVE_POLE_LENGTH,
-            'pole_mass': self.POLE_MASS,
-            'cart_mass': self.CART_MASS
+            'pole_effective_length': self.OVERRIDDEN_EFFECTIVE_POLE_LENGTH,
+            'pole_mass': self.OVERRIDDEN_POLE_MASS,
+            'cart_mass': self.OVERRIDDEN_CART_MASS
         }
         info['x_reference'] = self.X_GOAL
         info['u_reference'] = self.U_GOAL

--- a/safe_control_gym/envs/gym_control/cartpole.py
+++ b/safe_control_gym/envs/gym_control/cartpole.py
@@ -411,6 +411,11 @@ class CartPole(BenchmarkEnv):
         cost = {'cost_func': cost_func, 'vars': {'X': X, 'U': U, 'Xr': Xr, 'Ur': Ur, 'Q': Q, 'R': R}}
         # Additional params to cache
         params = {
+            # prior inertial properties
+            "pole_length": l,
+            "pole_mass": m,
+            "cart_mass": M,
+            # equilibrium point for linearization
             "X_EQ": np.atleast_2d(self.X_GOAL)[0,:].T,
             "U_EQ": np.atleast_2d(self.U_GOAL)[0,:],
         }

--- a/safe_control_gym/envs/gym_control/cartpole.py
+++ b/safe_control_gym/envs/gym_control/cartpole.py
@@ -378,7 +378,11 @@ class CartPole(BenchmarkEnv):
         self.PYB_CLIENT = -1
 
     def _setup_symbolic(self, prior_prop={}, **kwargs):
-        '''Creates symbolic (CasADi) models for dynamics, observation, and cost. '''
+        '''Creates symbolic (CasADi) models for dynamics, observation, and cost. 
+
+        Args:
+            prior_prop (dict): specify the prior inertial prop to use in the symbolic model.
+        '''
         l = prior_prop.get("pole_length", self.EFFECTIVE_POLE_LENGTH)
         m = prior_prop.get("pole_mass", self.POLE_MASS)
         M = prior_prop.get("cart_mass", self.CART_MASS)

--- a/safe_control_gym/envs/gym_pybullet_drones/quadrotor.py
+++ b/safe_control_gym/envs/gym_pybullet_drones/quadrotor.py
@@ -574,6 +574,12 @@ class Quadrotor(BaseAviary):
         }
         # Additional params to cache
         params = {
+            # prior inertial properties
+            "quad_mass": m, 
+            "quad_Iyy": Iyy,
+            "quad_Ixx": Ixx if "Ixx" in locals() else None,
+            "quad_Izz": Izz if "Izz" in locals() else None,
+            # equilibrium point for linearization
             "X_EQ": np.zeros(self.state_dim),
             "U_EQ": self.U_GOAL,
         }

--- a/safe_control_gym/envs/gym_pybullet_drones/quadrotor.py
+++ b/safe_control_gym/envs/gym_pybullet_drones/quadrotor.py
@@ -895,10 +895,8 @@ class Quadrotor(BaseAviary):
         info = {}
         info['symbolic_model'] = self.symbolic
         info['physical_parameters'] = {
-            'quadrotor_mass': self.MASS,
-            'quadrotor_ixx_inertia': self.J[0, 0],
-            'quadrotor_iyy_inertia': self.J[1, 1],
-            'quadrotor_izz_inertia': self.J[2, 2]
+            'quadrotor_mass': self.OVERRIDDEN_QUAD_MASS,
+            'quadrotor_inertia': self.OVERRIDDEN_QUAD_INERTIA,
         }
         info['x_reference'] = self.X_GOAL
         info['u_reference'] = self.U_GOAL

--- a/safe_control_gym/envs/gym_pybullet_drones/quadrotor.py
+++ b/safe_control_gym/envs/gym_pybullet_drones/quadrotor.py
@@ -884,16 +884,11 @@ class Quadrotor(BaseAviary):
         '''
         info = {}
         info['symbolic_model'] = self.symbolic
-        # TODO: reverse or delete commented out code once decided how to fix prior
-        # info['physical_parameters'] = {
-        #     'quadrotor_mass': self.MASS,
-        #     'quadrotor_iyy_inertia': self.J[1, 1]
-        # }
         info['physical_parameters'] = {
-            'quadrotor_mass': self.PRIOR_MASS,
-            'quadrotor_ixx_inertia': self.PRIOR_J[0, 0],
-            'quadrotor_iyy_inertia': self.PRIOR_J[1, 1],
-            'quadrotor_izz_inertia': self.PRIOR_J[2, 2]
+            'quadrotor_mass': self.MASS,
+            'quadrotor_ixx_inertia': self.J[0, 0],
+            'quadrotor_iyy_inertia': self.J[1, 1],
+            'quadrotor_izz_inertia': self.J[2, 2]
         }
         info['x_reference'] = self.X_GOAL
         info['u_reference'] = self.U_GOAL

--- a/safe_control_gym/envs/gym_pybullet_drones/quadrotor.py
+++ b/safe_control_gym/envs/gym_pybullet_drones/quadrotor.py
@@ -462,7 +462,11 @@ class Quadrotor(BaseAviary):
         return np.reshape(rgb, (h, w, 4))
 
     def _setup_symbolic(self, prior_prop={}, **kwargs):
-        '''Creates symbolic (CasADi) models for dynamics, observation, and cost. '''
+        '''Creates symbolic (CasADi) models for dynamics, observation, and cost. 
+        
+        Args:
+            prior_prop (dict): specify the prior inertial prop to use in the symbolic model.
+        '''
         m = prior_prop.get("M", self.MASS)
         Iyy = prior_prop.get("Iyy", self.J[1, 1])
         g, l = self.GRAVITY_ACC, self.L        

--- a/safe_control_gym/math_and_models/symbolic_systems.py
+++ b/safe_control_gym/math_and_models/symbolic_systems.py
@@ -23,7 +23,9 @@ class SymbolicModel():
                  cost,
                  dt=1e-3,
                  integration_algo='cvodes',
-                 funcs=None):
+                 funcs=None, 
+                 params=None,
+                 ):
         """
 
         """
@@ -44,6 +46,12 @@ class SymbolicModel():
             for name, func in funcs.items():
                 assert name not in self.__dict__
                 self.__dict__[name] = func
+        # Cache ohter parameters, for example, X_EQ and U_EQ
+        # that would be used in the controller via the symbolic model
+        if params is not None:
+            for name, param in params.items():
+                assert name not in self.__dict__
+                self.__dict__[name] = param
         # Variable dimensions.
         self.nx = self.x_sym.shape[0]
         self.nu = self.u_sym.shape[0]


### PR DESCRIPTION
This PR is meant for 
1. current PID for quadrotor uses the overridden system params from env instead of the prior params, which should be fixed
2. Cartpole seems to have an argument `prior_prop` to set the prior inertial properties (also used in the benchmark experiment for LQR^150%), but Quadrotor does not have such an argument, we should add this missing functionality in Quadrotor.
3. currently the prior params in env are the same as the default URDF params, but we need to vary the priors for testing the similarity metrics