### PR TITLE
Fixing LQR stabilization

### DIFF
--- a/experiments/lqr/config_overrides/cartpole/cartpole_stabilization.yaml
+++ b/experiments/lqr/config_overrides/cartpole/cartpole_stabilization.yaml
@@ -25,7 +25,7 @@ task_config:
 
   task: stabilization
   task_info:
-    stabilization_goal: [0.0, 0.0]
+    stabilization_goal: [1.0, 0.0]
     stabilization_goal_tolerance: 0.0
 
   episode_len_sec: 6

--- a/safe_control_gym/controllers/lqr/ilqr.py
+++ b/safe_control_gym/controllers/lqr/ilqr.py
@@ -62,9 +62,8 @@ class iLQR(BaseController):
         self.R = get_cost_weight_matrix(self.r_lqr, self.model.nu)
         self.env.set_cost_function_param(self.Q, self.R)
 
-        if self.env.TASK == Task.STABILIZATION:
-            self.gain = compute_lqr_gain(self.model, self.model.X_EQ, self.model.U_EQ,
-                                         self.Q, self.R, self.discrete_dynamics)
+        self.gain = compute_lqr_gain(self.model, self.model.X_EQ, self.model.U_EQ,
+                                     self.Q, self.R, self.discrete_dynamics)
 
         # Control stepsize.
         self.stepsize = self.model.dt
@@ -321,9 +320,6 @@ class iLQR(BaseController):
             gains_fb = -self.gain
             input_ff = self.gain @ self.env.X_GOAL + self.model.U_EQ
         elif self.env.TASK == Task.TRAJ_TRACKING:
-            self.gain = compute_lqr_gain(self.model, self.model.X_EQ,
-                                        self.model.U_EQ, self.Q, self.R,
-                                        self.discrete_dynamics)
             gains_fb = -self.gain
             input_ff = self.gain @ self.env.X_GOAL[step] + self.model.U_EQ
 

--- a/safe_control_gym/controllers/lqr/lqr.py
+++ b/safe_control_gym/controllers/lqr/lqr.py
@@ -35,9 +35,8 @@ class LQR(BaseController):
         self.R = get_cost_weight_matrix(r_lqr, self.model.nu)
         self.env.set_cost_function_param(self.Q, self.R)
 
-        if self.env.TASK == Task.STABILIZATION:
-            self.gain = compute_lqr_gain(self.model, self.model.X_EQ, self.model.U_EQ,
-                                         self.Q, self.R, self.discrete_dynamics)
+        self.gain = compute_lqr_gain(self.model, self.model.X_EQ, self.model.U_EQ,
+                                     self.Q, self.R, self.discrete_dynamics)
 
     def reset(self):
         '''Prepares for evaluation. '''
@@ -63,7 +62,4 @@ class LQR(BaseController):
         if self.env.TASK == Task.STABILIZATION:
             return -self.gain @ (obs - self.env.X_GOAL) + self.model.U_EQ
         elif self.env.TASK == Task.TRAJ_TRACKING:
-            self.gain = compute_lqr_gain(self.model, self.model.X_EQ,
-                                         self.model.U_EQ, self.Q, self.R,
-                                         self.discrete_dynamics)
             return -self.gain @ (obs - self.env.X_GOAL[step]) + self.model.U_EQ

--- a/safe_control_gym/controllers/lqr/lqr.py
+++ b/safe_control_gym/controllers/lqr/lqr.py
@@ -63,7 +63,7 @@ class LQR(BaseController):
         if self.env.TASK == Task.STABILIZATION:
             return -self.gain @ (obs - self.env.X_GOAL) + self.model.U_EQ
         elif self.env.TASK == Task.TRAJ_TRACKING:
-            self.gain = compute_lqr_gain(self.model, self.env.X_GOAL[step],
+            self.gain = compute_lqr_gain(self.model, self.model.X_EQ,
                                          self.model.U_EQ, self.Q, self.R,
                                          self.discrete_dynamics)
             return -self.gain @ (obs - self.env.X_GOAL[step]) + self.model.U_EQ

--- a/safe_control_gym/controllers/lqr/lqr.py
+++ b/safe_control_gym/controllers/lqr/lqr.py
@@ -36,7 +36,7 @@ class LQR(BaseController):
         self.env.set_cost_function_param(self.Q, self.R)
 
         if self.env.TASK == Task.STABILIZATION:
-            self.gain = compute_lqr_gain(self.model, self.model.X_EQ, self.model.U_EQ,
+            self.gain = compute_lqr_gain(self.model, self.env.X_GOAL, self.model.U_EQ,
                                          self.Q, self.R, self.discrete_dynamics)
 
     def reset(self):
@@ -61,7 +61,7 @@ class LQR(BaseController):
         step = self.extract_step(info)
 
         if self.env.TASK == Task.STABILIZATION:
-            return -self.gain @ (obs - self.model.X_EQ) + self.model.U_EQ
+            return -self.gain @ (obs - self.env.X_GOAL) + self.model.U_EQ
         elif self.env.TASK == Task.TRAJ_TRACKING:
             self.gain = compute_lqr_gain(self.model, self.env.X_GOAL[step],
                                          self.model.U_EQ, self.Q, self.R,

--- a/safe_control_gym/controllers/lqr/lqr.py
+++ b/safe_control_gym/controllers/lqr/lqr.py
@@ -36,7 +36,7 @@ class LQR(BaseController):
         self.env.set_cost_function_param(self.Q, self.R)
 
         if self.env.TASK == Task.STABILIZATION:
-            self.gain = compute_lqr_gain(self.model, self.env.X_GOAL, self.model.U_EQ,
+            self.gain = compute_lqr_gain(self.model, self.model.X_EQ, self.model.U_EQ,
                                          self.Q, self.R, self.discrete_dynamics)
 
     def reset(self):

--- a/safe_control_gym/envs/gym_control/cartpole.py
+++ b/safe_control_gym/envs/gym_control/cartpole.py
@@ -420,7 +420,7 @@ class CartPole(BenchmarkEnv):
             "pole_mass": m,
             "cart_mass": M,
             # equilibrium point for linearization
-            "X_EQ": np.atleast_2d(self.X_GOAL)[0,:].T,
+            "X_EQ": np.zeros(self.state_dim),
             "U_EQ": np.atleast_2d(self.U_GOAL)[0,:],
         }
         # Setup symbolic model.


### PR DESCRIPTION
Fixed small error in LQR code and changed the test to be more interesting. Essentially the problem stems from the fact we changed what X_EQ is in quadrotor, and so I'm unsure if it would cause errors in other places of the code. In quadrotor, it was always stabilizing to (0, 0) instead of the desired goal point since it expected X_EQ to hold the stabilization goal but it now is only an array of 0s. 

The code in cartpole does what I believe used to be done, setting X_EQ to be the first X_GOAL: https://github.com/utiasDSL/safe-control-gym/blob/bfe74b3327802d7578217ca1f42ddbdd49d4bf94/safe_control_gym/envs/gym_control/cartpole.py#L423

However, in quadrotor, this is not done (it is set to 0s instead): https://github.com/utiasDSL/safe-control-gym/blob/bfe74b3327802d7578217ca1f42ddbdd49d4bf94/safe_control_gym/envs/gym_pybullet_drones/quadrotor.py#L562

I think either of these approaches is fine, but we should decide since this is inconsistent and is causing problems. 