### PR TITLE
Changed instances of randint to integers as per issue #137

### DIFF
--- a/safe_control_gym/controllers/mpc/gp_mpc.py
+++ b/safe_control_gym/controllers/mpc/gp_mpc.py
@@ -712,7 +712,7 @@ class GPMPC(MPC):
                                                  self.train_iterations + validation_iterations,
                                                  random_state=self.seed)
             input_samples = np.array(input_samples)  # not being used currently
-            seeds = self.env.np_random.randint(0, 99999, size=self.train_iterations + validation_iterations)
+            seeds = self.env.np_random.integers(0, 99999, size=self.train_iterations + validation_iterations)
             for i in range(self.train_iterations + validation_iterations):
                 # For random initial state training.
                 #init_state = init_state_samples[i,:]

--- a/safe_control_gym/envs/disturbances.py
+++ b/safe_control_gym/envs/disturbances.py
@@ -100,7 +100,7 @@ class ImpulseDisturbance(Disturbance):
               env
               ):
         if self.step_offset is None:
-            self.current_step_offset = self.np_random.randint(self.max_step)
+            self.current_step_offset = self.np_random.integers(self.max_step)
         else:
             self.current_step_offset = self.step_offset
         self.current_peak_step = int(self.current_step_offset + self.duration / 2)
@@ -146,7 +146,7 @@ class StepDisturbance(Disturbance):
               env
               ):
         if self.step_offset is None:
-            self.current_step_offset = self.np_random.randint(self.max_step)
+            self.current_step_offset = self.np_random.integers(self.max_step)
         else:
             self.current_step_offset = self.step_offset
 


### PR DESCRIPTION
It seems like numpy seeding has changed and, based on how we do our seeding, now requires `randint` to be changed to `integers`. The syntax for the other distributions like `normal` and `uniform` has remained the same.