### PR TITLE
Fixing minor issues causing CBF to fail

### DIFF
--- a/examples/cbf/config_overrides/ppo_config.yaml
+++ b/examples/cbf/config_overrides/ppo_config.yaml
@@ -2,7 +2,7 @@ algo: ppo
 algo_config:
   # model args
   hidden_dim: 64
-  activation: relu
+  activation: tanh
   norm_obs: False
   norm_reward: False
   clip_obs: 10.0

--- a/examples/mpsc/config_overrides/cartpole/ppo_cartpole.yaml
+++ b/examples/mpsc/config_overrides/cartpole/ppo_cartpole.yaml
@@ -2,7 +2,7 @@ algo: ppo
 algo_config:
   # model args
   hidden_dim: 64
-  activation: relu
+  activation: tanh
   norm_obs: False
   norm_reward: False
   clip_obs: 10.0

--- a/examples/mpsc/config_overrides/quadrotor_2D/ppo_quadrotor_2D.yaml
+++ b/examples/mpsc/config_overrides/quadrotor_2D/ppo_quadrotor_2D.yaml
@@ -2,7 +2,7 @@ algo: ppo
 algo_config:
   # model args
   hidden_dim: 256
-  activation: relu
+  activation: tanh
 
   # loss args
   use_gae: True

--- a/examples/rl/config_overrides/quadrotor_2D/ppo_quadrotor_2D.yaml
+++ b/examples/rl/config_overrides/quadrotor_2D/ppo_quadrotor_2D.yaml
@@ -2,7 +2,7 @@ algo: ppo
 algo_config:
   # model args
   hidden_dim: 128
-  activation: relu
+  activation: tanh
 
   # loss args
   use_gae: True

--- a/examples/rl/config_overrides/quadrotor_3D/ppo_quadrotor_3D.yaml
+++ b/examples/rl/config_overrides/quadrotor_3D/ppo_quadrotor_3D.yaml
@@ -2,7 +2,7 @@ algo: ppo
 algo_config:
   # model args
   hidden_dim: 128
-  activation: relu
+  activation: tanh
 
   # loss args
   use_gae: True

--- a/safe_control_gym/controllers/ppo/ppo.yaml
+++ b/safe_control_gym/controllers/ppo/ppo.yaml
@@ -1,6 +1,6 @@
 # Model args
 hidden_dim: 64
-activation: 'tanh'
+activation: tanh
 norm_obs: False
 norm_reward: False
 clip_obs: 10

--- a/safe_control_gym/controllers/sac/sac.yaml
+++ b/safe_control_gym/controllers/sac/sac.yaml
@@ -1,6 +1,6 @@
 # model args
 hidden_dim: 256
-activation: 'relu'
+activation: relu
 norm_obs: False
 norm_reward: False
 clip_obs: 10.

--- a/safe_control_gym/experiments/base_experiment.py
+++ b/safe_control_gym/experiments/base_experiment.py
@@ -170,8 +170,9 @@ class BaseExperiment:
         if self.safety_filter is not None:
             physical_action = self.env.denormalize_action(action)
             unextended_obs = obs[:self.env.symbolic.nx]
-            certified_action, _ = self.safety_filter.certify_action(unextended_obs, physical_action, info)
-            action = self.env.normalize_action(certified_action)
+            certified_action, success = self.safety_filter.certify_action(unextended_obs, physical_action, info)
+            if success:
+                action = self.env.normalize_action(certified_action)
 
         return action
 


### PR DESCRIPTION
In https://github.com/utiasDSL/safe-control-gym/issues/155 it was found the CBF tests were no longer working. I troubleshooted and found two issues: The recovery behaviour can't be normalized (which I fixed in base_experiment.sh) and the default PPO activation is tanh but was set to relu by https://github.com/utiasDSL/safe-control-gym/pull/151. Fixed both issues. 