### PR TITLE
fix ilqr max step and add step counter

### DIFF
--- a/safe_control_gym/controllers/lqr/ilqr.py
+++ b/safe_control_gym/controllers/lqr/ilqr.py
@@ -48,7 +48,6 @@ class iLQR(BaseController):
         super().__init__(env_func, **kwargs)
 
         # Model parameters
-        self.env = env_func()
         self.q_lqr = q_lqr
         self.r_lqr = r_lqr
         self.discrete_dynamics = discrete_dynamics
@@ -59,7 +58,7 @@ class iLQR(BaseController):
         self.lamb_max = lamb_max
         self.epsilon = epsilon
 
-        self.env = env_func(info_in_reset=True, done_on_out_of_bound=True, seed=self.seed)
+        self.env = env_func(info_in_reset=True, done_on_out_of_bound=True)
 
         # Controller params.
         self.model = self.get_prior(self.env)


### PR DESCRIPTION
This pull request is a cleaned-up version of the previous closed ilqr PR and has the recent updates for the iLQR controller.

The main changes are

1. fixed the bug of the hard-coded max trajectory steps, and
2. added a step counter which will increase every time the `select_action` is called. This will help to run the controller on the hardware: when running the controller on the hardware, the controller will read the open-loop action of ilqr according to this counter, and the counter will be restricted to be no larger than `self.max_step`.
3. updated some docstrings

I am happy to address any questions you have. Also, let me know if the way I restrict the counter increment looks good to you [(here)](https://github.com/MingxuanChe/safe-control-gym/blob/29b18b4df6c24e12063adabddd9bb4bb33abe4ef/safe_control_gym/controllers/lqr/ilqr.py#L311C1-L312C32).
