### PR TITLE
Improvements over acados MPC formulation

### DIFF
--- a/examples/mpc/config_overrides/quadrotor_3D/mpc_acados_quadrotor_3D_tracking.yaml
+++ b/examples/mpc/config_overrides/quadrotor_3D/mpc_acados_quadrotor_3D_tracking.yaml
@@ -25,4 +25,5 @@ algo_config:
     randomize_prior_prop: False
     prior_prop_rand_info: null
   warmstart: True
+  warmstart_type: "heuristic"  # "heuristic", "lqr", "heuristic"
   use_RTI: False

--- a/examples/mpc/config_overrides/quadrotor_3D/mpc_acados_quadrotor_3D_tracking.yaml
+++ b/examples/mpc/config_overrides/quadrotor_3D/mpc_acados_quadrotor_3D_tracking.yaml
@@ -25,5 +25,5 @@ algo_config:
     randomize_prior_prop: False
     prior_prop_rand_info: null
   warmstart: True
-  warmstart_type: "heuristic"  # "heuristic", "lqr", "heuristic"
+  warmstart_type: "heuristic"  # "heuristic", "lqr", "ipopt"
   use_RTI: False

--- a/examples/mpc/config_overrides/quadrotor_3D/mpc_acados_quadrotor_3D_tracking.yaml
+++ b/examples/mpc/config_overrides/quadrotor_3D/mpc_acados_quadrotor_3D_tracking.yaml
@@ -25,5 +25,5 @@ algo_config:
     randomize_prior_prop: False
     prior_prop_rand_info: null
   warmstart: True
-  warmstart_type: "heuristic"  # "heuristic", "lqr", "ipopt"
+  warmstart_type: "tracking_goal"  # "tracking_goal", "lqr", "ipopt"
   use_RTI: False

--- a/examples/mpc/mpc_experiment.py
+++ b/examples/mpc/mpc_experiment.py
@@ -64,11 +64,11 @@ def run(gui=False, plot=True, n_episodes=1, n_steps=None, save_data=False):
 
 
 def post_analysis(state_stack, input_stack, env):
-    '''Plots the input and states to determine iLQR's success.
+    '''Plots the input and states to determine MPC's success.
 
     Args:
-        state_stack (ndarray): The list of observations of iLQR in the latest run.
-        input_stack (ndarray): The list of inputs of iLQR in the latest run.
+        state_stack (ndarray): The list of observations of MPC in the latest run.
+        input_stack (ndarray): The list of inputs of MPC in the latest run.
     '''
     model = env.symbolic
     stepsize = model.dt
@@ -81,20 +81,19 @@ def post_analysis(state_stack, input_stack, env):
         reference = np.tile(reference.reshape(1, model.nx), (plot_length, 1))
 
     # Plot states
-    fig, axs = plt.subplots(model.nx, figsize=(6, 9))
+    fig, axs = plt.subplots(model.nx, figsize=(6, 9), sharex=True)
     for k in range(model.nx):
         axs[k].plot(times, np.array(state_stack).transpose()[k, 0:plot_length], label='actual')
         axs[k].plot(times, reference.transpose()[k, 0:plot_length], color='r', label='desired')
         axs[k].set(ylabel=env.STATE_LABELS[k] + f'\n[{env.STATE_UNITS[k]}]')
         axs[k].yaxis.set_major_formatter(FormatStrFormatter('%.1f'))
-        if k != model.nx - 1:
-            axs[k].set_xticks([])
+        axs[k].set_xlim(times[0], times[-1])
     axs[0].set_title('State Trajectories')
     axs[-1].legend(ncol=3, bbox_transform=fig.transFigure, bbox_to_anchor=(1, 0), loc='lower right')
     axs[-1].set(xlabel='time (sec)')
     fig.tight_layout()
     # Plot inputs
-    fig, axs = plt.subplots(model.nu)
+    fig, axs = plt.subplots(model.nu, sharex=True)
     if model.nu == 1:
         axs = [axs]
     for k in range(model.nu):
@@ -105,6 +104,7 @@ def post_analysis(state_stack, input_stack, env):
         axs[k].set_ylim(0.8*env.physical_action_bounds[0][k], 1.2*env.physical_action_bounds[1][k])
         axs[k].axhline(env.physical_action_bounds[0][k], color="r", alpha=0.5, linestyle="--")
         axs[k].axhline(env.physical_action_bounds[1][k], color="r", alpha=0.5, linestyle="--")
+        axs[k].set_xlim(times[0], times[-1])
     axs[0].set_title('Input Trajectories')
     axs[-1].set(xlabel='time (sec)')
     fig.tight_layout()

--- a/examples/mpc/mpc_experiment.py
+++ b/examples/mpc/mpc_experiment.py
@@ -81,7 +81,7 @@ def post_analysis(state_stack, input_stack, env):
         reference = np.tile(reference.reshape(1, model.nx), (plot_length, 1))
 
     # Plot states
-    fig, axs = plt.subplots(model.nx)
+    fig, axs = plt.subplots(model.nx, figsize=(6, 9))
     for k in range(model.nx):
         axs[k].plot(times, np.array(state_stack).transpose()[k, 0:plot_length], label='actual')
         axs[k].plot(times, reference.transpose()[k, 0:plot_length], color='r', label='desired')
@@ -92,18 +92,22 @@ def post_analysis(state_stack, input_stack, env):
     axs[0].set_title('State Trajectories')
     axs[-1].legend(ncol=3, bbox_transform=fig.transFigure, bbox_to_anchor=(1, 0), loc='lower right')
     axs[-1].set(xlabel='time (sec)')
-
+    fig.tight_layout()
     # Plot inputs
-    _, axs = plt.subplots(model.nu)
+    fig, axs = plt.subplots(model.nu)
     if model.nu == 1:
         axs = [axs]
     for k in range(model.nu):
         axs[k].plot(times, np.array(input_stack).transpose()[k, 0:plot_length])
         axs[k].set(ylabel=f'input {k}')
         axs[k].set(ylabel=env.ACTION_LABELS[k] + f'\n[{env.ACTION_UNITS[k]}]')
-        axs[k].yaxis.set_major_formatter(FormatStrFormatter('%.1f'))
+        axs[k].yaxis.set_major_formatter(FormatStrFormatter('%.2f'))
+        axs[k].set_ylim(0.8*env.physical_action_bounds[0][k], 1.2*env.physical_action_bounds[1][k])
+        axs[k].axhline(env.physical_action_bounds[0][k], color="r", alpha=0.5, linestyle="--")
+        axs[k].axhline(env.physical_action_bounds[1][k], color="r", alpha=0.5, linestyle="--")
     axs[0].set_title('Input Trajectories')
     axs[-1].set(xlabel='time (sec)')
+    fig.tight_layout()
 
     plt.show()
 

--- a/safe_control_gym/controllers/mpc/mpc.py
+++ b/safe_control_gym/controllers/mpc/mpc.py
@@ -216,7 +216,7 @@ class MPC(BaseController):
                 u = self.lqr_gain @ (x_guess[:, i] - goal_states[:, i]) + np.atleast_2d(self.model.U_EQ)[0, :].T
                 u_guess[:, i] = u
                 x_guess[:, i + 1, None] = self.dynamics_func(x0=x_guess[:, i], p=u)['xf'].toarray()
-        elif self.compute_initial_guess_method == 'heuristic':
+        elif self.compute_initial_guess_method == 'tracking_goal':
             x_guess = goal_states
             u_guess = np.repeat(np.atleast_2d(self.U_EQ), self.T, axis=0).T
         else:

--- a/safe_control_gym/controllers/mpc/mpc.py
+++ b/safe_control_gym/controllers/mpc/mpc.py
@@ -216,6 +216,9 @@ class MPC(BaseController):
                 u = self.lqr_gain @ (x_guess[:, i] - goal_states[:, i]) + np.atleast_2d(self.model.U_EQ)[0, :].T
                 u_guess[:, i] = u
                 x_guess[:, i + 1, None] = self.dynamics_func(x0=x_guess[:, i], p=u)['xf'].toarray()
+        elif self.compute_initial_guess_method == 'heuristic':
+            x_guess = goal_states
+            u_guess = np.repeat(np.atleast_2d(self.U_EQ), self.T, axis=0).T
         else:
             raise Exception('Initial guess method not implemented.')
 
@@ -223,7 +226,7 @@ class MPC(BaseController):
         self.u_prev = u_guess
 
         # set the solver back
-        self.setup_optimizer(solver=self.solver)
+        self.setup_optimizer(solver=self.solver)  # TODO why? this method is also called from mpc_acados! at least move to line 209!
 
         return x_guess, u_guess
 

--- a/safe_control_gym/controllers/mpc/mpc_acados.py
+++ b/safe_control_gym/controllers/mpc/mpc_acados.py
@@ -70,7 +70,7 @@ class MPC_ACADOS(MPC):
         for k, v in locals().items():
             if k != 'self' and k != 'kwargs' and '__' not in k:
                 self.__dict__.update({k: v})
-        assert (warmstart_type == "ipopt" or warmstart_type=="heuristic" or warmstart_type == "lqr")
+        assert (warmstart_type == "ipopt" or warmstart_type=="tracking_goal" or warmstart_type == "lqr")
         super().__init__(
             env_func,
             horizon=horizon,

--- a/safe_control_gym/controllers/mpc/mpc_acados.py
+++ b/safe_control_gym/controllers/mpc/mpc_acados.py
@@ -447,6 +447,7 @@ class MPC_ACADOS(MPC):
         self.results_dict['horizon_states'].append(deepcopy(self.x_prev))
         self.results_dict['horizon_inputs'].append(deepcopy(self.u_prev))
         self.results_dict['goal_states'].append(deepcopy(goal_states))
+        self.results_dict['t_wall'].append(self.acados_ocp_solver.get_stats("time_tot"))
 
         self.prev_action = action
         if self.use_lqr_gain_and_terminal_cost:

--- a/safe_control_gym/experiments/base_experiment.py
+++ b/safe_control_gym/experiments/base_experiment.py
@@ -417,7 +417,10 @@ class MetricExtractor:
         return metrics
 
     def get_t_wall(self):
-        return self.data['controller_data'][0]['t_wall'][0]
+        try:
+            return self.data['controller_data'][0]['t_wall'][0]
+        except:
+            return np.nan
 
     def get_episode_data(self, key, postprocess_func=lambda x: x):
         '''Extract data field from recorded trajectory data, optionally postprocess each episode data (e.g. get sum).

--- a/safe_control_gym/experiments/base_experiment.py
+++ b/safe_control_gym/experiments/base_experiment.py
@@ -409,9 +409,15 @@ class MetricExtractor:
             'average_constraint_violation': np.asarray(self.get_episode_constraint_violation_steps()).mean(),
             'constraint_violation_std': np.asarray(self.get_episode_constraint_violation_steps()).std(),
             'constraint_violation': np.asarray(self.get_episode_constraint_violation_steps()) if len(self.get_episode_constraint_violation_steps()) > 1 else self.get_episode_constraint_violation_steps()[0],
+            'mean_t_wall_ms': np.asarray(self.get_t_wall()).mean()*1e3,
+            'median_t_wall_ms': np.median(np.asarray(self.get_t_wall()))*1e3,
+            'max_t_wall_ms': np.max(np.asarray(self.get_t_wall()))*1e3,
             # others ???
         }
         return metrics
+
+    def get_t_wall(self):
+        return self.data['controller_data'][0]['t_wall'][0]
 
     def get_episode_data(self, key, postprocess_func=lambda x: x):
         '''Extract data field from recorded trajectory data, optionally postprocess each episode data (e.g. get sum).

--- a/safe_control_gym/math_and_models/symbolic_systems.py
+++ b/safe_control_gym/math_and_models/symbolic_systems.py
@@ -69,7 +69,7 @@ class SymbolicModel():
         # Discrete time dynamics.
         self.fd_func = cs.integrator('fd', self.integration_algo, {'x': self.x_sym,
                                                                    'p': self.u_sym,
-                                                                   'ode': self.x_dot}, {'tf': self.dt}
+                                                                   'ode': self.x_dot}, 0, self.dt
                                      )
         # Observation model.
         self.g_func = cs.Function('g', [self.x_sym, self.u_sym], [self.y_sym], ['x', 'u'], ['g'])
@@ -101,7 +101,7 @@ class SymbolicModel():
                 'x': self.x_eval,
                 'p': cs.vertcat(self.u_eval, self.x_sym, self.u_sym),
                 'ode': self.x_dot_linear
-            }, {'tf': self.dt})
+            }, 0, self.dt)
         # Linearized observation model.
         self.y_linear = self.y_sym + self.dgdx @ (
             self.x_eval - self.x_sym) + self.dgdu @ (self.u_eval - self.u_sym)

--- a/safe_control_gym/safety_filters/mpsc/linear_mpsc.py
+++ b/safe_control_gym/safety_filters/mpsc/linear_mpsc.py
@@ -101,7 +101,7 @@ class LINEAR_MPSC(MPSC):
                     'x': delta_x,
                     'p': delta_u,
                     'ode': x_dot_lin_vec
-                }, {'tf': self.dt}
+                }, 0, self.dt
             )
 
         self.dynamics_func = dynamics_func


### PR DESCRIPTION
I had some problems in rebasing #181 and updating #182.
So I created this new PR to have a clean git history, sorry for the mess.

A quick comparison by running the tracking problem for the drone of a 3D lemniscate 
**Order: casadi/ipopt, acados/sqp, acados/sqp_rti**
Considerable speed up of computation time (cf. _t_wall_ metrics)
![Screenshot 2024-12-05 at 15 20 06](https://github.com/user-attachments/assets/47620faa-6f4b-4e07-8db0-94cc81a3798e) ![Screenshot 2024-12-05 at 15 19 44](https://github.com/user-attachments/assets/6a2f1114-868a-4afb-912c-9fd21e34c0d0) ![Screenshot 2024-12-05 at 15 22 08](https://github.com/user-attachments/assets/cfb539bb-5a68-4522-8108-b93d75dfb4f4)