### PR TITLE
Removing info_in_reset

### DIFF
--- a/examples/cbf/config_overrides/cartpole_config.yaml
+++ b/examples/cbf/config_overrides/cartpole_config.yaml
@@ -2,7 +2,6 @@ task_config:
   seed: 42
   ctrl_freq: 25
   pyb_freq: 1000
-  info_in_reset: True
 
   cost: quadratic
   task: stabilization

--- a/examples/hpo/gp_mpc/config_overrides/cartpole/cartpole_stab.yaml
+++ b/examples/hpo/gp_mpc/config_overrides/cartpole/cartpole_stab.yaml
@@ -28,7 +28,6 @@ task_config:
     pole_length: 0.5
     pole_mass: 0.1
   inertial_prop_randomization_info: null
-  info_in_reset: false
   init_state:
     init_x: 0.0
     init_x_dot: 0.0

--- a/examples/hpo/rl/config_overrides/cartpole/cartpole_stab.yaml
+++ b/examples/hpo/rl/config_overrides/cartpole/cartpole_stab.yaml
@@ -1,5 +1,4 @@
 task_config:
-  info_in_reset: True
   ctrl_freq: 15
   pyb_freq: 750
   physics: pyb

--- a/examples/lqr/config_overrides/cartpole/cartpole_stabilization.yaml
+++ b/examples/lqr/config_overrides/cartpole/cartpole_stabilization.yaml
@@ -1,6 +1,5 @@
 task_config:
   seed: 42
-  info_in_reset: True
   ctrl_freq: 15
   pyb_freq: 750
   physics: pyb

--- a/examples/lqr/config_overrides/cartpole/cartpole_tracking.yaml
+++ b/examples/lqr/config_overrides/cartpole/cartpole_tracking.yaml
@@ -1,6 +1,5 @@
 task_config:
   seed: 42
-  info_in_reset: True
   ctrl_freq: 15
   pyb_freq: 750
   physics: pyb

--- a/examples/lqr/config_overrides/quadrotor_2D/quadrotor_2D_stabilization.yaml
+++ b/examples/lqr/config_overrides/quadrotor_2D/quadrotor_2D_stabilization.yaml
@@ -1,6 +1,5 @@
 task_config:
   seed: 1337
-  info_in_reset: True
   ctrl_freq: 50
   pyb_freq: 1000
   gui: False

--- a/examples/lqr/config_overrides/quadrotor_2D/quadrotor_2D_tracking.yaml
+++ b/examples/lqr/config_overrides/quadrotor_2D/quadrotor_2D_tracking.yaml
@@ -1,6 +1,5 @@
 task_config:
   seed: 1337
-  info_in_reset: True
   ctrl_freq: 50
   pyb_freq: 1000
   gui: False

--- a/examples/lqr/config_overrides/quadrotor_3D/quadrotor_3D_stabilization.yaml
+++ b/examples/lqr/config_overrides/quadrotor_3D/quadrotor_3D_stabilization.yaml
@@ -1,6 +1,5 @@
 task_config:
   seed: 1337
-  info_in_reset: True
   ctrl_freq: 50
   pyb_freq: 1000
   gui: False

--- a/examples/lqr/config_overrides/quadrotor_3D/quadrotor_3D_tracking.yaml
+++ b/examples/lqr/config_overrides/quadrotor_3D/quadrotor_3D_tracking.yaml
@@ -1,6 +1,5 @@
 task_config:
   seed: 1337
-  info_in_reset: True
   ctrl_freq: 50
   pyb_freq: 1000
   gui: False

--- a/examples/mpc/config_overrides/cartpole/cartpole_stabilization.yaml
+++ b/examples/mpc/config_overrides/cartpole/cartpole_stabilization.yaml
@@ -1,6 +1,5 @@
 task_config:
   seed: 42
-  info_in_reset: True
   ctrl_freq: 15
   pyb_freq: 750
   physics: pyb

--- a/examples/mpc/config_overrides/cartpole/cartpole_tracking.yaml
+++ b/examples/mpc/config_overrides/cartpole/cartpole_tracking.yaml
@@ -1,6 +1,5 @@
 task_config:
   seed: 42
-  info_in_reset: True
   ctrl_freq: 15
   pyb_freq: 750
   physics: pyb

--- a/examples/mpc/config_overrides/quadrotor_2D/quadrotor_2D_stabilization.yaml
+++ b/examples/mpc/config_overrides/quadrotor_2D/quadrotor_2D_stabilization.yaml
@@ -1,6 +1,5 @@
 task_config:
   seed: 1337
-  info_in_reset: True
   ctrl_freq: 50
   pyb_freq: 1000
   gui: False

--- a/examples/mpc/config_overrides/quadrotor_2D/quadrotor_2D_tracking.yaml
+++ b/examples/mpc/config_overrides/quadrotor_2D/quadrotor_2D_tracking.yaml
@@ -1,6 +1,5 @@
 task_config:
   seed: 1337
-  info_in_reset: True
   ctrl_freq: 50
   pyb_freq: 1000
   gui: False

--- a/examples/mpc/config_overrides/quadrotor_3D/quadrotor_3D_stabilization.yaml
+++ b/examples/mpc/config_overrides/quadrotor_3D/quadrotor_3D_stabilization.yaml
@@ -1,6 +1,5 @@
 task_config:
   seed: 1337
-  info_in_reset: True
   ctrl_freq: 50
   pyb_freq: 1000
   gui: False

--- a/examples/mpc/config_overrides/quadrotor_3D/quadrotor_3D_tracking.yaml
+++ b/examples/mpc/config_overrides/quadrotor_3D/quadrotor_3D_tracking.yaml
@@ -1,6 +1,5 @@
 task_config:
   seed: 1337
-  info_in_reset: True
   ctrl_freq: 50
   pyb_freq: 1000
   gui: False

--- a/examples/mpsc/config_overrides/cartpole/cartpole_stab.yaml
+++ b/examples/mpsc/config_overrides/cartpole/cartpole_stab.yaml
@@ -1,6 +1,5 @@
 task_config:
   seed: 42
-  info_in_reset: True
   ctrl_freq: 15
   pyb_freq: 750
   physics: pyb

--- a/examples/mpsc/config_overrides/cartpole/cartpole_track.yaml
+++ b/examples/mpsc/config_overrides/cartpole/cartpole_track.yaml
@@ -1,6 +1,5 @@
 task_config:
   seed: 42
-  info_in_reset: True
   ctrl_freq: 15
   pyb_freq: 750
   physics: pyb

--- a/examples/mpsc/config_overrides/quadrotor_2D/quadrotor_2D_stab.yaml
+++ b/examples/mpsc/config_overrides/quadrotor_2D/quadrotor_2D_stab.yaml
@@ -1,6 +1,5 @@
 task_config:
   seed: 1337
-  info_in_reset: True
   ctrl_freq: 50
   pyb_freq: 1000
   physics: pyb

--- a/examples/mpsc/config_overrides/quadrotor_2D/quadrotor_2D_track.yaml
+++ b/examples/mpsc/config_overrides/quadrotor_2D/quadrotor_2D_track.yaml
@@ -1,6 +1,5 @@
 task_config:
   seed: 1337
-  info_in_reset: True
   ctrl_freq: 50
   pyb_freq: 1000
   physics: pyb

--- a/examples/mpsc/config_overrides/quadrotor_3D/quadrotor_3D_stab.yaml
+++ b/examples/mpsc/config_overrides/quadrotor_3D/quadrotor_3D_stab.yaml
@@ -1,6 +1,5 @@
 task_config:
   seed: 1337
-  info_in_reset: True
   ctrl_freq: 50
   pyb_freq: 1000
   physics: pyb

--- a/examples/no_controller/verbose_api.yaml
+++ b/examples/no_controller/verbose_api.yaml
@@ -1,6 +1,5 @@
 cartpole_config:
   seed: 1337
-  info_in_reset: True
   ctrl_freq: 50
   pyb_freq: 50
   gui: False
@@ -91,7 +90,6 @@ cartpole_config:
 
 quadrotor_config:
   seed: 1337
-  info_in_reset: True
   ctrl_freq: 60
   pyb_freq: 240
   gui: False

--- a/examples/pid/config_overrides/quadrotor_2D/quadrotor_2D_stabilization.yaml
+++ b/examples/pid/config_overrides/quadrotor_2D/quadrotor_2D_stabilization.yaml
@@ -1,6 +1,5 @@
 task_config:
   seed: 42
-  info_in_reset: True
   ctrl_freq: 50
   pyb_freq: 1000
   gui: False

--- a/examples/pid/config_overrides/quadrotor_2D/quadrotor_2D_tracking.yaml
+++ b/examples/pid/config_overrides/quadrotor_2D/quadrotor_2D_tracking.yaml
@@ -1,6 +1,5 @@
 task_config:
   seed: 1337
-  info_in_reset: True
   ctrl_freq: 50
   pyb_freq: 1000
   gui: False

--- a/examples/pid/config_overrides/quadrotor_3D/quadrotor_3D_stabilization.yaml
+++ b/examples/pid/config_overrides/quadrotor_3D/quadrotor_3D_stabilization.yaml
@@ -1,6 +1,5 @@
 task_config:
   seed: 1337
-  info_in_reset: True
   ctrl_freq: 50
   pyb_freq: 1000
   gui: False

--- a/examples/pid/config_overrides/quadrotor_3D/quadrotor_3D_tracking.yaml
+++ b/examples/pid/config_overrides/quadrotor_3D/quadrotor_3D_tracking.yaml
@@ -1,6 +1,5 @@
 task_config:
   seed: 42
-  info_in_reset: True
   ctrl_freq: 50
   pyb_freq: 1000
   gui: False

--- a/examples/rl/config_overrides/cartpole/cartpole_stab.yaml
+++ b/examples/rl/config_overrides/cartpole/cartpole_stab.yaml
@@ -1,6 +1,5 @@
 task_config:
   seed: 42
-  info_in_reset: True
   ctrl_freq: 15
   pyb_freq: 750
   physics: pyb

--- a/examples/rl/config_overrides/cartpole/cartpole_track.yaml
+++ b/examples/rl/config_overrides/cartpole/cartpole_track.yaml
@@ -1,6 +1,5 @@
 task_config:
   seed: 42
-  info_in_reset: True
   ctrl_freq: 15
   pyb_freq: 750
   physics: pyb

--- a/examples/rl/config_overrides/quadrotor_2D/quadrotor_2D_stab.yaml
+++ b/examples/rl/config_overrides/quadrotor_2D/quadrotor_2D_stab.yaml
@@ -1,6 +1,5 @@
 task_config:
   seed: 1337
-  info_in_reset: True
   ctrl_freq: 50
   pyb_freq: 1000
   physics: pyb

--- a/examples/rl/config_overrides/quadrotor_2D/quadrotor_2D_track.yaml
+++ b/examples/rl/config_overrides/quadrotor_2D/quadrotor_2D_track.yaml
@@ -1,6 +1,5 @@
 task_config:
   seed: 1337
-  info_in_reset: True
   ctrl_freq: 50
   pyb_freq: 1000
   physics: pyb

--- a/examples/rl/config_overrides/quadrotor_3D/quadrotor_3D_stab.yaml
+++ b/examples/rl/config_overrides/quadrotor_3D/quadrotor_3D_stab.yaml
@@ -1,6 +1,5 @@
 task_config:
   seed: 1337
-  info_in_reset: True
   ctrl_freq: 50
   pyb_freq: 1000
   physics: pyb

--- a/examples/rl/config_overrides/quadrotor_3D/quadrotor_3D_track.yaml
+++ b/examples/rl/config_overrides/quadrotor_3D/quadrotor_3D_track.yaml
@@ -1,6 +1,5 @@
 task_config:
   seed: 1337
-  info_in_reset: True
   ctrl_freq: 50
   pyb_freq: 1000
   physics: pyb

--- a/safe_control_gym/controllers/lqr/ilqr.py
+++ b/safe_control_gym/controllers/lqr/ilqr.py
@@ -58,7 +58,7 @@ class iLQR(BaseController):
         self.lamb_max = lamb_max
         self.epsilon = epsilon
 
-        self.env = env_func(info_in_reset=True, done_on_out_of_bound=True)
+        self.env = env_func(done_on_out_of_bound=True)
 
         # Controller params.
         self.model = self.get_prior(self.env)

--- a/safe_control_gym/envs/benchmark_env.py
+++ b/safe_control_gym/envs/benchmark_env.py
@@ -54,7 +54,6 @@ class BenchmarkEnv(gym.Env, ABC):
     def __init__(self,
                  output_dir=None,
                  seed=None,
-                 info_in_reset: bool = False,
                  gui: bool = False,
                  verbose: bool = False,
                  normalized_rl_action_space: bool = False,
@@ -91,8 +90,6 @@ class BenchmarkEnv(gym.Env, ABC):
         Args:
             output_dir (str, optional): Path to directory to save any env outputs.
             seed (int, optional): Seed for the random number generator.
-            info_in_reset (bool, optional): Whether .reset() returns a dictionary with the
-                                            environment's symbolic model.
             gui (bool, optional): Whether to show PyBullet's GUI.
             verbose (bool, optional): If to suppress environment print statetments.
             normalized_rl_action_space (bool, optional): Whether to normalize the action space.
@@ -192,7 +189,6 @@ class BenchmarkEnv(gym.Env, ABC):
         self.seed(seed)
         self.initial_reset = False
         self.at_reset = False
-        self.INFO_IN_RESET = info_in_reset
 
     def seed(self,
              seed=None

--- a/safe_control_gym/envs/gym_control/cartpole.py
+++ b/safe_control_gym/envs/gym_control/cartpole.py
@@ -32,7 +32,6 @@ class CartPole(BenchmarkEnv):
     multiple cost functions, stabilization and trajectory tracking references.
 
     task_config:
-        info_in_reset: True
         randomized_inertial_prop: True
         inertial_prop_randomization_info:
             pole_length:
@@ -338,10 +337,7 @@ class CartPole(BenchmarkEnv):
         obs, info = self._get_observation(), self._get_reset_info()
         obs, info = super().after_reset(obs, info)
         # Return either an observation and dictionary or just the observation.
-        if self.INFO_IN_RESET:
-            return obs, info
-        else:
-            return obs
+        return obs, info
 
     def render(self, mode='human'):
         '''Retrieves a frame from PyBullet rendering.

--- a/safe_control_gym/envs/gym_control/cartpole.yaml
+++ b/safe_control_gym/envs/gym_control/cartpole.yaml
@@ -1,5 +1,4 @@
 # Simulation options
-info_in_reset: False
 ctrl_freq: 50
 pyb_freq: 50
 gui: False

--- a/safe_control_gym/envs/gym_pybullet_drones/quadrotor.py
+++ b/safe_control_gym/envs/gym_pybullet_drones/quadrotor.py
@@ -387,10 +387,7 @@ class Quadrotor(BaseAviary):
         obs, info = super().after_reset(obs, info)
 
         # Return either an observation and dictionary or just the observation.
-        if self.INFO_IN_RESET:
-            return obs, info
-        else:
-            return obs
+        return obs, info
 
     def step(self, action):
         '''Advances the environment by one control step.

--- a/safe_control_gym/envs/gym_pybullet_drones/quadrotor.yaml
+++ b/safe_control_gym/envs/gym_pybullet_drones/quadrotor.yaml
@@ -1,5 +1,4 @@
 # Simulation options
-info_in_reset: False
 ctrl_freq: 60
 pyb_freq: 240
 physics: pyb

--- a/safe_control_gym/experiments/base_experiment.py
+++ b/safe_control_gym/experiments/base_experiment.py
@@ -188,11 +188,8 @@ class BaseExperiment:
             obs (ndarray): The initial observation.
             info (dict): The initial info.
         '''
-        if self.env.INFO_IN_RESET:
-            obs, info = self.env.reset(seed=seed)
-        else:
-            obs = self.env.reset(seed=seed)
-            info = None
+        obs, info = self.env.reset(seed=seed)
+
         if ctrl_data is not None:
             for data_key, data_val in self.ctrl.results_dict.items():
                 ctrl_data[data_key].append(np.array(deepcopy(data_val)))
@@ -325,26 +322,17 @@ class RecordDataWrapper(gym.Wrapper):
     def reset(self, **kwargs):
         '''Wrapper for the gym.env reset function.'''
 
-        if self.env.INFO_IN_RESET:
-            obs, info = self.env.reset(**kwargs)
-            if 'symbolic_model' in info:
-                info.pop('symbolic_model')
-            if 'symbolic_constraints' in info:
-                info.pop('symbolic_constraints')
-            step_data = dict(
-                obs=obs, info=info, state=self.env.state
-            )
-            for key, val in step_data.items():
-                self.episode_data[key].append(val)
-            return obs, info
-        else:
-            obs = self.env.reset(**kwargs)
-            step_data = dict(
-                obs=obs, state=self.env.state
-            )
-            for key, val in step_data.items():
-                self.episode_data[key].append(val)
-            return obs
+        obs, info = self.env.reset(**kwargs)
+        if 'symbolic_model' in info:
+            info.pop('symbolic_model')
+        if 'symbolic_constraints' in info:
+            info.pop('symbolic_constraints')
+        step_data = dict(
+            obs=obs, info=info, state=self.env.state
+        )
+        for key, val in step_data.items():
+            self.episode_data[key].append(val)
+        return obs, info
 
     def step(self, action):
         '''Wrapper for the gym.env step function.'''


### PR DESCRIPTION
`info_in_reset` is a useless configuration flag as it is always set to True. It is no longer used in Gymnasium, which was the original reason for including it. When it is set to False, it causes issues throughout the gym as we have generally programmed the gym always assuming it is True. I have removed it everywhere. 