### PR TITLE
Real-time GUI Visualization

### DIFF
--- a/safe_control_gym/experiments/base_experiment.py
+++ b/safe_control_gym/experiments/base_experiment.py
@@ -48,7 +48,15 @@ class BaseExperiment:
 
         self.reset()
 
-    def run_evaluation(self, training=False, n_episodes=None, n_steps=None, done_on_max_steps=None, log_freq=None, verbose=True, **kwargs):
+    def run_evaluation(self,
+                       training=False,
+                       n_episodes=None,
+                       n_steps=None,
+                       done_on_max_steps=None,
+                       log_freq=None,
+                       verbose=True,
+                       visualization_time_multiplier=1,
+                       **kwargs):
         '''Evaluate a trained controller.
 
         Args:
@@ -56,11 +64,14 @@ class BaseExperiment:
             n_episodes (int): Number of runs to execute.
             n_steps (int): The number of steps to collect in total.
             log_freq (int): The frequency with which to log information.
+            visualization_time_multiplier (float): Changes speed of visualization, where 1x is realtime,
+                2x is twice as fast as real-time, etc. None results in fastest visualization.
 
         Returns:
             trajs_data (dict): The raw data from the executed runs.
             metrics (dict): The metrics calculated from the raw data.
         '''
+        self.visualization_time_multiplier = visualization_time_multiplier
 
         if not training:
             self.reset()
@@ -174,10 +185,12 @@ class BaseExperiment:
             if success:
                 action = self.env.normalize_action(certified_action)
 
-        if self.last_step_timestep is not None and self.env.GUI is True:
+        if self.last_step_timestep is not None and \
+                self.env.GUI is True and \
+                self.visualization_time_multiplier is not None:
             # Sleep to maintain real-time pacing
             elapsed = time.time() - self.last_step_timestep
-            time.sleep(max(0, 1.0 / self.env.CTRL_FREQ - elapsed))
+            time.sleep(max(0, 1.0 / self.env.CTRL_FREQ / self.visualization_time_multiplier - elapsed))
         self.last_step_timestep = time.time()
 
         return action


### PR DESCRIPTION
Up until now, when the GUI was turned on it ran at the pace of the gym, which is often many times faster than real-time. This caused the visualization to be useless, since you can't actually tell whats happening. This came up recently in https://github.com/utiasDSL/safe-control-gym/issues/186. I have fixed this by simply sleeping the base_experiment when GUI is on. 

I don't foresee any issues, especially since the GUI is used so rarely, unless someone wants the GUI to run quickly to collect a video or something? But I don't expect that would be done for more than 1 or 2 videos since it would take up massive space, so I think it should be ok. 