### PR TITLE
Minor changes to examples

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
     -   id: double-quote-string-fixer
 
 -   repo: https://github.com/pycqa/isort
-    rev: 5.13.2
+    rev: 6.0.1
     hooks:
       - id: isort
         name: isort
@@ -45,7 +45,7 @@ repos:
         files: (^tests/|^safe_control_gym/math_and_models/transformations.py)
 
 -   repo: https://github.com/PyCQA/flake8
-    rev: 7.1.1
+    rev: 7.1.2
     hooks:
     -   id: flake8
         name: flake8_default

--- a/examples/mpc/mpc_experiment.py
+++ b/examples/mpc/mpc_experiment.py
@@ -44,7 +44,7 @@ def run(gui=False, plot=True, n_episodes=1, n_steps=None, save_data=False):
 
     # Run the experiment.
     experiment = BaseExperiment(env=env, ctrl=ctrl)
-    trajs_data, metrics = experiment.run_evaluation(training=True, n_episodes=n_episodes, n_steps=n_steps)
+    trajs_data, metrics = experiment.run_evaluation(n_episodes=n_episodes, n_steps=n_steps)
 
     if plot:
         for i in range(len(trajs_data['obs'])):

--- a/examples/mpc/mpc_experiment.py
+++ b/examples/mpc/mpc_experiment.py
@@ -64,11 +64,11 @@ def run(gui=False, plot=True, n_episodes=1, n_steps=None, save_data=False):
 
 
 def post_analysis(state_stack, input_stack, env):
-    '''Plots the input and states to determine iLQR's success.
+    '''Plots the input and states to determine MPC's success.
 
     Args:
-        state_stack (ndarray): The list of observations of iLQR in the latest run.
-        input_stack (ndarray): The list of inputs of iLQR in the latest run.
+        state_stack (ndarray): The list of observations of MPC in the latest run.
+        input_stack (ndarray): The list of inputs of MPC in the latest run.
     '''
     model = env.symbolic
     stepsize = model.dt

--- a/safe_control_gym/controllers/lqr/ilqr.py
+++ b/safe_control_gym/controllers/lqr/ilqr.py
@@ -342,6 +342,10 @@ class iLQR(BaseController):
         self.ite_counter = 0
         self.traj_step = 0
 
+    def reset_before_run(self, obs=None, info=None, env=None):
+        self.traj_step = 0
+        self.setup_results_dict()
+
     def run(self, env=None, max_steps=500, training=True):
         '''Runs evaluation with current policy.
 

--- a/safe_control_gym/experiments/base_experiment.py
+++ b/safe_control_gym/experiments/base_experiment.py
@@ -46,8 +46,6 @@ class BaseExperiment:
             self.train_env = RecordDataWrapper(self.train_env)
         self.safety_filter = safety_filter
 
-        self.reset()
-
     def run_evaluation(self,
                        training=False,
                        n_episodes=None,


### PR DESCRIPTION
Was responding to an issue and reviewed the examples and found some minor issues:

1. I don't know why the training parameter is set to true in the MPC example, this seems incorrect. 
2. The PID example uses the ctrl.env as the actual environment. This is not necessarily wrong but not aligned with the rest of our examples. 
3. iLQR does not have a reset_before_run function. This causes issues since we switched to traj_step instead of using info in select_action (should at some point align on that). 
4. Removed what seems to be an unnecessary reset call in base_experiment. We generally reset very frequently. 

Let me know if you foresee any issues with these updates. 