### PR TITLE
Resolve NumPy round calls warnings

### DIFF
--- a/safe_control_gym/envs/constraints.py
+++ b/safe_control_gym/envs/constraints.py
@@ -106,7 +106,7 @@ class Constraint:
             value (ndarray): The evaluation of the constraint.
         '''
         env_value = self.get_env_constraint_var(env)
-        return np.round_(np.atleast_1d(np.squeeze(self.sym_func(np.array(env_value, ndmin=1)))), decimals=self.decimals)
+        return np.round(np.atleast_1d(np.squeeze(self.sym_func(np.array(env_value, ndmin=1)))), decimals=self.decimals)
 
     def is_violated(self,
                     env,
@@ -443,7 +443,7 @@ class SymmetricStateConstraint(BoundedConstraint):
         self.num_constraints = self.bound.shape[0]
 
     def get_value(self, env):
-        c_value = np.round_(np.abs(self.constraint_filter @ env.state) - self.bound, decimals=self.decimals)
+        c_value = np.round(np.abs(self.constraint_filter @ env.state) - self.bound, decimals=self.decimals)
         return c_value
 
     # TODO: temp addition


### PR DESCRIPTION
# PR Summary
This small PR resolves the deprecation warnings coming from NumPy `round_` function which was renamed to `round`:
```python
/home/runner/work/safe-control-gym/safe-control-gym/safe_control_gym/envs/constraints.py:566: DeprecationWarning: `round_` is deprecated as of NumPy 1.25.0, and will be removed in NumPy 2.0. Please use `round` instead.
```