### PR TITLE
General refactoring of MPC code and especially mpc_acados

### DIFF
--- a/examples/mpc/mpc_experiment.sh
+++ b/examples/mpc/mpc_experiment.sh
@@ -6,7 +6,7 @@
 # SYS='quadrotor_2D'
 SYS='quadrotor_3D'
 
-#TASK='stabilization'
+# TASK='stabilization'
 TASK='tracking'
 
 # ALGO='mpc'

--- a/safe_control_gym/controllers/mpc/mpc_acados.py
+++ b/safe_control_gym/controllers/mpc/mpc_acados.py
@@ -5,25 +5,14 @@ from copy import deepcopy
 import casadi as cs
 import numpy as np
 import scipy
-from termcolor import colored
+from acados_template import AcadosModel, AcadosOcp, AcadosOcpSolver
 
 from safe_control_gym.controllers.mpc.mpc import MPC
 from safe_control_gym.controllers.mpc.mpc_utils import set_acados_constraint_bound
-from safe_control_gym.utils.utils import timing
-
-try:
-    from acados_template import AcadosModel, AcadosOcp, AcadosOcpSolver
-except ImportError as e:
-    print(colored(f'Error: {e}', 'red'))
-    print(colored('acados not installed, cannot use acados-based controller. Exiting.', 'red'))
-    print(colored('- To build and install acados, follow the instructions at https://docs.acados.org/installation/index.html', 'yellow'))
-    print(colored('- To set up the acados python interface, follow the instructions at https://docs.acados.org/python_interface/index.html', 'yellow'))
-    print()
-    exit()
 
 
 class MPC_ACADOS(MPC):
-    '''MPC with full nonlinear model.'''
+    '''MPC with full nonlinear model solved with acados.'''
 
     def __init__(
             self,
@@ -31,17 +20,10 @@ class MPC_ACADOS(MPC):
             horizon: int = 5,
             q_mpc: list = [1],
             r_mpc: list = [1],
-            warmstart: bool = True,
             soft_constraints: bool = False,
             soft_penalty: float = 10000,
-            terminate_run_on_done: bool = True,
             constraint_tol: float = 1e-6,
-            # runner args
-            # shared/base args
-            output_dir: str = 'results/temp',
             additional_constraints: list = None,
-            use_gpu: bool = False,
-            seed: int = 0,
             use_RTI: bool = False,
             use_lqr_gain_and_terminal_cost: bool = False,
             **kwargs
@@ -49,122 +31,78 @@ class MPC_ACADOS(MPC):
         '''Creates task and controller.
 
         Args:
-            env_func (Callable): function to instantiate task/environment.
-            horizon (int): mpc planning horizon.
-            q_mpc (list): diagonals of state cost weight.
-            r_mpc (list): diagonals of input/action cost weight.
-            warmstart (bool): if to initialize from previous iteration.
+            env_func (Callable): Function to instantiate task/environment.
+            horizon (int): MPC planning horizon.
+            q_mpc (list): Diagonals of state cost weight.
+            r_mpc (list): Diagonals of input/action cost weight.
             soft_constraints (bool): Formulate the constraints as soft constraints.
             soft_penalty (float): Penalty added to acados formulation for soft constraints.
-            terminate_run_on_done (bool): Terminate the run when the environment returns done or not.
-            constraint_tol (float): Tolerance to add the the constraint as sometimes solvers are not exact.
-            output_dir (str): output directory to write logs and results.
-            additional_constraints (list): List of additional constraints
-            use_gpu (bool): False (use cpu) True (use cuda).
-            seed (int): random seed.
+            constraint_tol (float): Tolerance to add to the constraint as sometimes solvers are not exact.
+            additional_constraints (list): List of additional constraints.
             use_RTI (bool): Real-time iteration for acados.
             use_lqr_gain_and_terminal_cost (bool): Use LQR ancillary gain and terminal cost for the MPC.
         '''
-        for k, v in locals().items():
-            if k != 'self' and k != 'kwargs' and '__' not in k:
-                self.__dict__.update({k: v})
         super().__init__(
             env_func,
             horizon=horizon,
             q_mpc=q_mpc,
             r_mpc=r_mpc,
-            warmstart=warmstart,
             soft_constraints=soft_constraints,
             soft_penalty=soft_penalty,
-            terminate_run_on_done=terminate_run_on_done,
             constraint_tol=constraint_tol,
-            output_dir=output_dir,
             additional_constraints=additional_constraints,
-            # compute_initial_guess_method='ipopt',  # use ipopt initial guess by default
             use_lqr_gain_and_terminal_cost=use_lqr_gain_and_terminal_cost,
-            use_gpu=use_gpu,
-            seed=seed,
             **kwargs
         )
-        # acados settings
+
         self.use_RTI = use_RTI
 
-    @timing
-    def reset(self):
-        '''Prepares for training or evaluation.'''
-        print(colored('Resetting MPC', 'green'))
-        self.x_guess = None
-        self.u_guess = None
-        super().reset()
-        self.acados_model = None
-        self.ocp = None
-        self.acados_ocp_solver = None
-        # Dynamics model.
-        self.setup_acados_model()
-        # Acados optimizer.
-        self.setup_acados_optimizer()
-        self.acados_ocp_solver = AcadosOcpSolver(self.ocp)
+    def reset_before_run(self, obs=None, info=None, env=None):
+        '''Reinitialize just the controller before a new run.
+
+        Args:
+            obs (ndarray): The initial observation for the new run.
+            info (dict): The first info of the new run.
+            env (BenchmarkEnv): The environment to be used for the new run.'''
+
+        super().reset_before_run(obs, info, env)
+        self.acados_ocp_solver.reset()
 
     def setup_acados_model(self) -> AcadosModel:
         '''Sets up symbolic model for acados.
 
         Returns:
             acados_model (AcadosModel): acados model object.
-
-        Other options to set up the model:
-        f_expl = self.model.x_dot (explicit continuous-time dynamics)
-        f_impl = self.model.x_dot_acados - f_expl (implicit continuous-time dynamics)
-        model.f_impl_expr = f_impl
-        model.f_expl_expr = f_expl
         '''
-
         acados_model = AcadosModel()
         acados_model.x = self.model.x_sym
         acados_model.u = self.model.u_sym
         acados_model.name = self.env.NAME
 
-        # set up rk4 (acados need symbolic expression of dynamics, not function)
-        k1 = self.model.fc_func(acados_model.x, acados_model.u)
-        k2 = self.model.fc_func(acados_model.x + self.dt / 2 * k1, acados_model.u)
-        k3 = self.model.fc_func(acados_model.x + self.dt / 2 * k2, acados_model.u)
-        k4 = self.model.fc_func(acados_model.x + self.dt * k3, acados_model.u)
-        f_disc = acados_model.x + self.dt / 6 * (k1 + 2 * k2 + 2 * k3 + k4)
+        # Dynamics model
+        acados_model.f_expl_expr = self.model.fc_func(acados_model.x, acados_model.u)
 
-        acados_model.disc_dyn_expr = f_disc
-
-        # store meta information # NOTE: unit is missing
+        # Store meta information # NOTE: unit is missing
         acados_model.x_labels = self.env.STATE_LABELS
         acados_model.u_labels = self.env.ACTION_LABELS
         acados_model.t_label = 'time'
 
-        self.acados_model = acados_model
+        return acados_model
 
-    @timing
-    def compute_initial_guess(self, init_state, goal_states=None):
-        '''Use IPOPT to get an initial guess of the solution.
-
-        Args:
-            init_state (ndarray): Initial state.
-            goal_states (ndarray): Goal states.
-        '''
-        x_val, u_val = super().compute_initial_guess(init_state, goal_states)
-        self.x_guess = x_val
-        self.u_guess = u_val
-
-    def setup_acados_optimizer(self):
+    def setup_optimizer(self, *args):
         '''Sets up nonlinear optimization problem.'''
         nx, nu = self.model.nx, self.model.nu
         ny = nx + nu
         ny_e = nx
 
-        # create ocp object to formulate the OCP
+        # Create ocp object to formulate the OCP
         ocp = AcadosOcp()
-        ocp.model = self.acados_model
+        ocp.model = self.setup_acados_model()
 
-        # set dimensions
-        ocp.dims.N = self.T  # prediction horizon
+        # Set dimensions
+        ocp.dims.N = self.T  # Prediction horizon
 
-        # set cost (NOTE: safe-control-gym uses quadratic cost)
+        # Set cost (NOTE: safe-control-gym uses quadratic cost)
         ocp.cost.cost_type = 'LINEAR_LS'
         ocp.cost.cost_type_e = 'LINEAR_LS'
         ocp.cost.W = scipy.linalg.block_diag(self.Q, self.R)
@@ -174,33 +112,35 @@ class MPC_ACADOS(MPC):
         ocp.cost.Vu = np.zeros((ny, nu))
         ocp.cost.Vu[nx:(nx + nu), :nu] = np.eye(nu)
         ocp.cost.Vx_e = np.eye(nx)
-        # placeholder y_ref and y_ref_e (will be set in select_action)
+
+        # Placeholder y_ref and y_ref_e (will be set in select_action)
         ocp.cost.yref = np.zeros((ny, ))
         ocp.cost.yref_e = np.zeros((ny_e, ))
 
         # Constraints
-        # general constraint expressions
+        # General constraint expressions
         state_constraint_expr_list = []
         input_constraint_expr_list = []
-        for sc_i, state_constraint in enumerate(self.state_constraints_sym):
+        for state_constraint in self.state_constraints_sym:
             state_constraint_expr_list.append(state_constraint(ocp.model.x))
-        for ic_i, input_constraint in enumerate(self.input_constraints_sym):
+        for input_constraint in self.input_constraints_sym:
             input_constraint_expr_list.append(input_constraint(ocp.model.u))
 
         h_expr_list = state_constraint_expr_list + input_constraint_expr_list
         h_expr = cs.vertcat(*h_expr_list)
         h0_expr = cs.vertcat(*h_expr_list)
-        he_expr = cs.vertcat(*state_constraint_expr_list)  # terminal constraints are only state constraints
-        # pass the constraints to the ocp object
+        he_expr = cs.vertcat(*state_constraint_expr_list)  # Terminal constraints are only state constraints
+
+        # Pass the constraints to the ocp object
         ocp = self.processing_acados_constraints_expression(ocp, h0_expr, h_expr, he_expr)
 
-        # slack costs for nonlinear constraints
+        # Slack costs for nonlinear constraints
         if self.soft_constraints:
-            # slack variables for all constraints
+            # Slack variables for all constraints
             ocp.constraints.Jsh_0 = np.eye(h0_expr.shape[0])
             ocp.constraints.Jsh = np.eye(h_expr.shape[0])
             ocp.constraints.Jsh_e = np.eye(he_expr.shape[0])
-            # slack penalty
+            # Slack penalty
             L2_pen = self.soft_penalty
             L1_pen = self.soft_penalty
             ocp.cost.Zl_0 = L2_pen * np.ones(h0_expr.shape[0])
@@ -216,26 +156,22 @@ class MPC_ACADOS(MPC):
             ocp.cost.zl_e = L1_pen * np.ones(he_expr.shape[0])
             ocp.cost.zu_e = L1_pen * np.ones(he_expr.shape[0])
 
-        # placeholder initial state constraint
+        # Placeholder initial state constraint
         x_init = np.zeros((nx))
         ocp.constraints.x0 = x_init
 
-        # set up solver options
+        # Set up solver options
         ocp.solver_options.qp_solver = 'PARTIAL_CONDENSING_HPIPM'
         ocp.solver_options.hessian_approx = 'GAUSS_NEWTON'
-        ocp.solver_options.integrator_type = 'DISCRETE'
+        ocp.solver_options.integrator_type = 'ERK'
         ocp.solver_options.nlp_solver_type = 'SQP' if not self.use_RTI else 'SQP_RTI'
-        ocp.solver_options.nlp_solver_max_iter = 25 if not self.use_RTI else 1
+        ocp.solver_options.nlp_solver_max_iter = 200 if not self.use_RTI else 1
         ocp.solver_options.globalization = 'MERIT_BACKTRACKING'
-        # ocp.solver_options.globalization = 'FUNNEL_L1PEN_LINESEARCH' if not self.use_RTI else 'MERIT_BACKTRACKING'
-        ocp.solver_options.tf = self.T * self.dt  # prediction horizon
+        ocp.solver_options.tf = self.T * self.dt  # Prediction horizon
 
-        # c code generation
-        # NOTE: when using GP-MPC, a separated directory is needed;
-        # otherwise, Acados solver can read the wrong c code
         ocp.code_export_directory = self.output_dir + '/mpc_c_generated_code'
 
-        self.ocp = ocp
+        self.acados_ocp_solver = AcadosOcpSolver(ocp)
 
     def processing_acados_constraints_expression(self,
                                                  ocp: AcadosOcp,
@@ -244,21 +180,15 @@ class MPC_ACADOS(MPC):
                                                  he_expr: cs.MX,
                                                  ) -> AcadosOcp:
         '''Preprocess the constraints to be compatible with acados.
-            Args:
-                ocp (AcadosOcp): acados ocp object
-                h0_expr (cs.MX expression): initial state constraints
-                h_expr (cs.MX expression): state and input constraints
-                he_expr (cs.MX expression): terminal state constraints
-            Returns:
-                ocp (AcadosOcp): acados ocp object with constraints set.
 
-        An alternative way to set the constraints is to use bounded constraints of acados:
-        # bounded input constraints
-        idxbu = np.where(np.sum(self.env.constraints.input_constraints[0].constraint_filter, axis=0) != 0)[0]
-        ocp.constraints.Jbu = np.eye(nu)
-        ocp.constraints.lbu = self.env.constraints.input_constraints[0].lower_bounds
-        ocp.constraints.ubu = self.env.constraints.input_constraints[0].upper_bounds
-        ocp.constraints.idxbu = idxbu # active constraints dimension
+        Args:
+            ocp (AcadosOcp): acados ocp object
+            h0_expr (cs.MX expression): initial state constraints
+            h_expr (cs.MX expression): state and input constraints
+            he_expr (cs.MX expression): terminal state constraints
+
+        Returns:
+            ocp (AcadosOcp): acados ocp object with constraints set.
         '''
 
         ub = {'h': set_acados_constraint_bound(h_expr, 'ub', self.constraint_tol),
@@ -269,23 +199,24 @@ class MPC_ACADOS(MPC):
               'h0': set_acados_constraint_bound(h0_expr, 'lb'),
               'he': set_acados_constraint_bound(he_expr, 'lb'), }
 
-        # make sure all the ub and lb are 1D numpy arrays
+        # Make sure all the ub and lb are 1D numpy arrays
         # (see: https://discourse.acados.org/t/infeasible-qps-when-using-nonlinear-casadi-constraint-expressions/1595/5?u=mxche)
         for key in ub.keys():
             ub[key] = ub[key].flatten() if ub[key].ndim != 1 else ub[key]
             lb[key] = lb[key].flatten() if lb[key].ndim != 1 else lb[key]
-        # check ub and lb dimensions
+
+        # Check ub and lb dimensions
         for key in ub.keys():
             assert ub[key].ndim == 1, f'ub[{key}] is not 1D numpy array'
             assert lb[key].ndim == 1, f'lb[{key}] is not 1D numpy array'
         assert ub['h'].shape == lb['h'].shape, 'h_ub and h_lb have different shapes'
 
-        # pass the constraints to the ocp object
+        # Pass the constraints to the ocp object
         ocp.model.con_h_expr_0, ocp.model.con_h_expr, ocp.model.con_h_expr_e = \
             h0_expr, h_expr, he_expr
         ocp.dims.nh_0, ocp.dims.nh, ocp.dims.nh_e = \
             h0_expr.shape[0], h_expr.shape[0], he_expr.shape[0]
-        # assign constraints upper and lower bounds
+        # Assign constraints upper and lower bounds
         ocp.constraints.uh_0 = ub['h0']
         ocp.constraints.lh_0 = lb['h0']
         ocp.constraints.uh = ub['h']
@@ -295,7 +226,6 @@ class MPC_ACADOS(MPC):
 
         return ocp
 
-    @timing
     def select_action(self,
                       obs,
                       info=None
@@ -304,34 +234,16 @@ class MPC_ACADOS(MPC):
 
         Args:
             obs (ndarray): Current state/observation.
-            info (dict): Current info
+            info (dict): Current info.
 
         Returns:
             action (ndarray): Input/action to the task/env.
         '''
-        nx, nu = self.model.nx, self.model.nu
-        # set initial condition (0-th state)
+        # Set initial condition (0-th state)
         self.acados_ocp_solver.set(0, 'lbx', obs)
         self.acados_ocp_solver.set(0, 'ubx', obs)
 
-        # warm-starting solver
-        # NOTE: only for ipopt warm-starting; since acados
-        # has a built-in warm-starting mechanism.
-        if self.warmstart:
-            if self.x_guess is None or self.u_guess is None:
-                # compute initial guess with IPOPT
-                self.compute_initial_guess(obs)
-            for idx in range(self.T + 1):
-                init_x = self.x_guess[:, idx]
-                self.acados_ocp_solver.set(idx, 'x', init_x)
-            for idx in range(self.T):
-                if nu == 1:
-                    init_u = np.array([self.u_guess[idx]])
-                else:
-                    init_u = self.u_guess[:, idx]
-                self.acados_ocp_solver.set(idx, 'u', init_u)
-
-        # set reference for the control horizon
+        # Set reference for the control horizon
         goal_states = self.get_references()
         if self.mode == 'tracking':
             self.traj_step += 1
@@ -343,53 +255,26 @@ class MPC_ACADOS(MPC):
         y_ref_e = goal_states[:, -1]
         self.acados_ocp_solver.set(self.T, 'yref', y_ref_e)
 
-        # solve the optimization problem
-        if self.use_RTI:
-            # preparation phase
-            self.acados_ocp_solver.options_set('rti_phase', 1)
-            status = self.acados_ocp_solver.solve()
+        # Solve the optimization problem
+        status = self.acados_ocp_solver.solve()
+        if status not in [0, 2]:
+            raise Exception(f'acados returned status {status}. Exiting.')
+        if status == 2:
+            print(f'acados returned status {status}. ')
+        action = self.acados_ocp_solver.get(0, 'u')
 
-            # feedback phase
-            self.acados_ocp_solver.options_set('rti_phase', 2)
-            status = self.acados_ocp_solver.solve()
-
-            if status not in [0, 2]:
-                self.acados_ocp_solver.print_statistics()
-                raise Exception(f'acados returned status {status}. Exiting.')
-            if status == 2:
-                print(f'acados returned status {status}. ')
-
-            action = self.acados_ocp_solver.get(0, 'u')
-
-        elif not self.use_RTI:
-            status = self.acados_ocp_solver.solve()
-            if status not in [0, 2]:
-                self.acados_ocp_solver.print_statistics()
-                raise Exception(f'acados returned status {status}. Exiting.')
-            if status == 2:
-                print(f'acados returned status {status}. ')
-            action = self.acados_ocp_solver.get(0, 'u')
-
-        # get the open-loop solution
-        if self.x_prev is None and self.u_prev is None:
-            self.x_prev = np.zeros((nx, self.T + 1))
-            self.u_prev = np.zeros((nu, self.T))
-        if self.u_prev is not None and nu == 1:
-            self.u_prev = self.u_prev.reshape((1, -1))
-        for i in range(self.T + 1):
-            self.x_prev[:, i] = self.acados_ocp_solver.get(i, 'x')
+        # Get the open-loop solution
+        self.x_prev = np.zeros((self.model.nx, self.T + 1))
+        self.u_prev = np.zeros((self.model.nu, self.T))
         for i in range(self.T):
+            self.x_prev[:, i] = self.acados_ocp_solver.get(i, 'x')
             self.u_prev[:, i] = self.acados_ocp_solver.get(i, 'u')
-        if nu == 1:
-            self.u_prev = self.u_prev.flatten()
+        self.x_prev[:, -1] = self.acados_ocp_solver.get(self.T, 'x')
 
-        self.x_guess = self.x_prev
-        self.u_guess = self.u_prev
         self.results_dict['horizon_states'].append(deepcopy(self.x_prev))
         self.results_dict['horizon_inputs'].append(deepcopy(self.u_prev))
         self.results_dict['goal_states'].append(deepcopy(goal_states))
 
-        self.prev_action = action
         if self.use_lqr_gain_and_terminal_cost:
             action += self.lqr_gain @ (obs - self.x_prev[:, 0])
 

--- a/safe_control_gym/utils/utils.py
+++ b/safe_control_gym/utils/utils.py
@@ -7,8 +7,6 @@ import os
 import random
 import subprocess
 import sys
-import time
-from functools import wraps
 
 import gymnasium as gym
 import imageio
@@ -16,7 +14,6 @@ import munch
 import numpy as np
 import torch
 import yaml
-from termcolor import colored
 
 
 def mkdirs(*paths):
@@ -196,18 +193,3 @@ def unwrap_wrapper(env, wrapper_class):
 def is_wrapped(env, wrapper_class):
     '''Check if a given environment has been wrapped with a given wrapper.'''
     return unwrap_wrapper(env, wrapper_class) is not None
-
-
-def timing(f):
-    '''Decorator for measuring the time of a function.
-       The elapsed time is stored in the function object.
-    '''
-    @wraps(f)
-    def wrap(*args, **kw):
-        ts = time.time()
-        result = f(*args, **kw)
-        te = time.time()
-        wrap.elapsed_time = te - ts
-        print(colored(f'func:{f.__name__} took: {wrap.elapsed_time:.3f} sec', 'blue'))
-        return result
-    return wrap


### PR DESCRIPTION
Made some major changes:
- Removed initial guesses entirely
- Removed the timing code
- Moved the `run` function to gp-mpc since it is the only one that uses it. @MingxuanChe said it is also possible to replace this with the base_experiment class, which would be ideal. 
- Improved the reset/reset_before_run code
- Did a major cleanup of mpc_acados, simplifying it as much as possible while including some suggestions from Andrea Ghezzi to prepare for his PR. 