### PR TITLE
acados MPC edits

### DIFF
--- a/safe_control_gym/controllers/mpc/mpc_acados.py
+++ b/safe_control_gym/controllers/mpc/mpc_acados.py
@@ -105,7 +105,7 @@ class MPC_ACADOS(MPC):
         # Set cost (NOTE: safe-control-gym uses quadratic cost)
         ocp.cost.cost_type = 'LINEAR_LS'
         ocp.cost.cost_type_e = 'LINEAR_LS'
-        ocp.cost.W = scipy.linalg.block_diag(self.Q, self.R)
+        ocp.cost.W = scipy.linalg.block_diag(self.Q/self.dt, self.R/self.dt)
         ocp.cost.W_e = self.Q if not self.use_lqr_gain_and_terminal_cost else self.P
         ocp.cost.Vx = np.zeros((ny, nx))
         ocp.cost.Vx[:nx, :nx] = np.eye(nx)

--- a/safe_control_gym/envs/constraints.py
+++ b/safe_control_gym/envs/constraints.py
@@ -178,7 +178,7 @@ class Constraint:
             raise ValueError('[ERROR] the tolerance dimension does not match the number of constraints.')
 
 
-class QuadraticContstraint(Constraint):
+class QuadraticConstraint(Constraint):
     '''Constraint class for constraints of the form x.T @ P @ x <= b.'''
 
     def __init__(self,
@@ -300,7 +300,7 @@ class BoundedConstraint(LinearConstraint):
         Args:
             env (BenchmarkEnv): The environment to constraint.
             lower_bounds (ndarray or list): Lower bound of constraint.
-            upper_bounds (ndarray or list): Uppbound of constraint.
+            upper_bounds (ndarray or list): Upper bound of constraint.
             constrained_variable (ConstrainedVariableType): Type of constraint.
             strict (optional, bool): Whether the constraint is violated also when equal to its threshold.
             active_dims (list or int): List specifying which dimensions the constraint is active for. Note that
@@ -639,7 +639,7 @@ class ConstraintList:
 
 GENERAL_CONSTRAINTS = {
     'linear_constraint': LinearConstraint,
-    'quadratic_constraint': QuadraticContstraint,
+    'quadratic_constraint': QuadraticConstraint,
     'bounded_constraint': BoundedConstraint,
     'default_constraint': DefaultConstraint
 }

--- a/safe_control_gym/safety_filters/mpsc/linear_mpsc.py
+++ b/safe_control_gym/safety_filters/mpsc/linear_mpsc.py
@@ -18,7 +18,7 @@ from pytope import Polytope
 from safe_control_gym.controllers.lqr.lqr_utils import discretize_linear_system
 from safe_control_gym.controllers.mpc.mpc_utils import rk_discrete
 from safe_control_gym.envs.benchmark_env import Environment, Task
-from safe_control_gym.envs.constraints import ConstrainedVariableType, LinearConstraint, QuadraticContstraint
+from safe_control_gym.envs.constraints import ConstrainedVariableType, LinearConstraint, QuadraticConstraint
 from safe_control_gym.safety_filters.mpsc.mpsc import MPSC
 from safe_control_gym.safety_filters.mpsc.mpsc_utils import (Cost_Function, compute_RPI_set,
                                                              ellipse_bounding_box, pontryagin_difference_AABB)
@@ -133,7 +133,7 @@ class LINEAR_MPSC(MPSC):
         self.P = compute_RPI_set(A_cl, w, self.tau)
         self.omega_AABB_verts = ellipse_bounding_box(self.P)
         self.tighten_state_and_input_constraints()
-        self.omega_constraint = QuadraticContstraint(self.env,
+        self.omega_constraint = QuadraticConstraint(self.env,
                                                      self.P,
                                                      1.0,
                                                      constrained_variable=ConstrainedVariableType.STATE)
@@ -192,7 +192,7 @@ class LINEAR_MPSC(MPSC):
         self.P = parameters['P']
         self.omega_AABB_verts = ellipse_bounding_box(self.P)
         self.tighten_state_and_input_constraints()
-        self.omega_constraint = QuadraticContstraint(self.env,
+        self.omega_constraint = QuadraticConstraint(self.env,
                                                      self.P,
                                                      1.0,
                                                      constrained_variable=ConstrainedVariableType.STATE)
@@ -261,7 +261,7 @@ class LINEAR_MPSC(MPSC):
         self.tightened_state_constraint = tightened_state_constraint_func(env=self.env,
                                                                           constrained_variable=ConstrainedVariableType.STATE)
 
-        self.simple_terminal_set = QuadraticContstraint(env=self.env,
+        self.simple_terminal_set = QuadraticConstraint(env=self.env,
                                                         P=np.eye(self.model.nx),
                                                         b=self.env.TASK_INFO['stabilization_goal_tolerance'],
                                                         constrained_variable=ConstrainedVariableType.STATE)


### PR DESCRIPTION
I changed the constraints handling for acados, only bounds are supported otherwise I throw an error.
I also scaled the cost matrix since acados wants the continuous time version (they will be automatically integrated in the cost).

Questions for @Federico-PizarroBejarano
- I would be happy to rename "warmstart" into "initial guess"
- Should I introduce different "initial guess" strategies like "ipopt", "lqr", "tracking_cost"? (similar to [here](https://github.com/aghezz1/pept/blob/main/safe_control_gym/controllers/mpc/mpc_acados.yaml)