### PR TITLE
Fixing mse in cartpole and quadrotor

### DIFF
--- a/safe_control_gym/envs/constraints.py
+++ b/safe_control_gym/envs/constraints.py
@@ -446,7 +446,6 @@ class SymmetricStateConstraint(BoundedConstraint):
         c_value = np.round(np.abs(self.constraint_filter @ env.state) - self.bound, decimals=self.decimals)
         return c_value
 
-    # TODO: temp addition
     def check_tolerance_shape(self):
         '''Note we compare tolerance shape to bound shape (instead of num_constraints), since
         num_constraints will be set as 2x due to subclassing BoundedConstraint,


### PR DESCRIPTION
Thanks to Adam inquiring about the RMSE calculations, I found an error in the Cartpole RMSE calculation. It previously did not consider the stabilization goal or trajectory at all, assuming the goal was always stabilizing to the origin. I fixed this and some other things:

#### Tasks Done:
1. Changed cartpole MSE calculation to consider goal
2. Added `info_mse_metric_state_weight` to cartpole
3. Changed both cartpole and quadrotor MSE calc to normalize angles

#### Remaining Questions:
1. The default `info_mse_metric_state_weight` ignores angles and velocities (except it includes angle in cartpole and 2D quad). Unsure if we should leave it or change it to value all states equally. 
2. Realized the current gym does not provide MSE, constraint violations, and some other stuff on the initial state. I.e. the RMSE is calculated from the second state onwards. Unsure if that is what we want. 